### PR TITLE
Fix rigify layers

### DIFF
--- a/src/mpfb/entities/rig.py
+++ b/src/mpfb/entities/rig.py
@@ -143,6 +143,13 @@ class Rig:
             bone.use_inherit_rotation = bone_info["use_inherit_rotation"]
             bone.inherit_scale = bone_info["inherit_scale"]
             if "layers" in bone_info:
+
+                # Mask layers to allow deselection
+                i = 0
+                for layer in bone_info["layers"]:
+                    bone.layers[i] = True
+                    i = i + 1
+
                 i = 0
                 for layer in bone_info["layers"]:
                     bone.layers[i] = layer

--- a/src/mpfb/entities/rig.py
+++ b/src/mpfb/entities/rig.py
@@ -170,11 +170,8 @@ class Rig:
             if "rigify_parameters" in bone_info:
                 for key in bone_info["rigify_parameters"].keys():
                     value = bone_info["rigify_parameters"][key]
-                    if isinstance(value, list):
-                        pass
-                    else:
-                        _LOG.debug("Will attempt to set bone.parameters.", key)
-                        setattr(bone.rigify_parameters, str(key), value)
+                    _LOG.debug("Will attempt to set bone.parameters.", key)
+                    setattr(bone.rigify_parameters, str(key), value)
 
         bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
 


### PR DESCRIPTION
I found two problems with the Rigify rig creation, 

1. When iterating through the bone layers to flip them on or off attempts were being made to turn off the last layer where a bone was, so Blender wouldn't allow that -- the net effect is that most of the bones ended up _also_ on layer 1, the face layer.  This messed up layer selection, bone groups, colours, etc.
2. The FK and Tweak bone layer configuration for helpers was not being attempted.  I found out that one could just assign the array with the configuration in one go!

Please see below, and try out, how much friendlier the rig becomes with this corrected metarig :-) 

![image](https://user-images.githubusercontent.com/95913/131231333-9ecbb454-b979-486e-883c-6ae331b70282.png)
