### PR TITLE
Remove python warnings, for issue #44

### DIFF
--- a/src/mpfb/entities/objectproperties/humanproperties/cupsize.json
+++ b/src/mpfb/entities/objectproperties/humanproperties/cupsize.json
@@ -1,7 +1,7 @@
 {
     "type": "float",
     "name": "cupsize",
-    "description": "The cup size of the breasts. On male characters, anything but 0.5 will look strange.",
+    "description": "The cup size of the breasts. On male characters, anything but 0.5 will look strange",
     "label": "Cup size",
     "default": 0.5
 }

--- a/src/mpfb/entities/objectproperties/humanproperties/proportions.json
+++ b/src/mpfb/entities/objectproperties/humanproperties/proportions.json
@@ -1,7 +1,7 @@
 {
     "type": "float",
     "name": "proportions",
-    "description": "The proportions of the character, where 0.0 is uncommon proportions and 1.0 is ideal proportions.",
+    "description": "The proportions of the character, where 0.0 is uncommon proportions and 1.0 is ideal proportions",
     "label": "Proportions",
     "default": 0.5
 }

--- a/src/mpfb/services/uiservice.py
+++ b/src/mpfb/services/uiservice.py
@@ -1,5 +1,5 @@
 
-import os, bpy
+import os, bpy, re
 from fnmatch import fnmatch
 from .logservice import LogService
 from .locationservice import LocationService
@@ -159,6 +159,9 @@ class _UiService():
 
     def get_importer_eye_settings_panel_list(self):
         return self.get_value("importer_eye_settings_panel_list")
+
+    def as_valid_identifier(self, raw_string):
+       return re.sub(r'[^a-zA-Z0-9_]', "_", raw_string)
 
 
 UiService = _UiService() # pylint: disable=C0103

--- a/src/mpfb/ui/addrig/properties/import_weights.json
+++ b/src/mpfb/ui/addrig/properties/import_weights.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "import_weights",
-    "description": "Also import weights (if available) and set up the corresponding vertex groups.",
+    "description": "Also import weights (if available) and set up the corresponding vertex groups",
     "label": "Import weights",
     "default": true
 }

--- a/src/mpfb/ui/addrig/properties/import_weights_rigify.json
+++ b/src/mpfb/ui/addrig/properties/import_weights_rigify.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "import_weights_rigify",
-    "description": "Also import weights and set up the corresponding vertex groups.",
+    "description": "Also import weights and set up the corresponding vertex groups",
     "label": "Import weights",
     "default": true
 }

--- a/src/mpfb/ui/assetlibrary/assetlibrarypanel.py
+++ b/src/mpfb/ui/assetlibrary/assetlibrarypanel.py
@@ -20,7 +20,7 @@ _NOASSETS = [
 
 
 class _Abstract_Asset_Library_Panel(bpy.types.Panel):
-    """Asset library panel."""
+    """Asset library panel"""
 
     bl_label = "SHOULD BE OVERRIDDEN"
     bl_space_type = "VIEW_3D"

--- a/src/mpfb/ui/assetlibrary/assetlibrarypanel.py
+++ b/src/mpfb/ui/assetlibrary/assetlibrarypanel.py
@@ -7,6 +7,7 @@ from mpfb.services.assetservice import AssetService, ASSET_LIBRARY_SECTIONS
 from mpfb.services.humanservice import HumanService
 from mpfb.services.objectservice import ObjectService
 from mpfb.ui.assetlibrary.assetsettingspanel import ASSET_SETTINGS_PROPERTIES
+from mpfb.services.uiservice import UiService
 from mpfb.ui.assetspanel import FILTER_PROPERTIES
 
 _LOG = LogService.get_logger("assetlibrary.assetlibrarypanel")
@@ -25,6 +26,7 @@ class _Abstract_Asset_Library_Panel(bpy.types.Panel):
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_parent_id = "MPFB_PT_Assets_Panel"
+    bl_category = UiService.get_value("CLOTHESCATEGORY")
     bl_options = {'DEFAULT_CLOSED'}
 
     basemesh = None

--- a/src/mpfb/ui/assetlibrary/operators/loadlibraryclothes.py
+++ b/src/mpfb/ui/assetlibrary/operators/loadlibraryclothes.py
@@ -10,7 +10,7 @@ from mpfb import ClassManager
 _LOG = LogService.get_logger("assetlibrary.loadlibraryclothes")
 
 class MPFB_OT_Load_Library_Clothes_Operator(bpy.types.Operator):
-    """Load MHCLO from asset library."""
+    """Load MHCLO from asset library"""
     bl_idname = "mpfb.load_library_clothes"
     bl_label = "Load"
     bl_options = {'REGISTER', 'UNDO'}

--- a/src/mpfb/ui/assetlibrary/operators/loadlibrarymaterial.py
+++ b/src/mpfb/ui/assetlibrary/operators/loadlibrarymaterial.py
@@ -13,7 +13,7 @@ from mpfb import ClassManager
 _LOG = LogService.get_logger("assetlibrary.loadlibraryskin")
 
 class MPFB_OT_Load_Library_Material_Operator(bpy.types.Operator):
-    """Replace the current material with the selected alternative material."""
+    """Replace the current material with the selected alternative material"""
     bl_idname = "mpfb.load_library_material"
     bl_label = "Load"
     bl_options = {'REGISTER', 'UNDO'}

--- a/src/mpfb/ui/assetlibrary/operators/loadlibraryproxy.py
+++ b/src/mpfb/ui/assetlibrary/operators/loadlibraryproxy.py
@@ -15,7 +15,7 @@ from mpfb import ClassManager
 _LOG = LogService.get_logger("assetlibrary.loadlibraryproxy")
 
 class MPFB_OT_Load_Library_Proxy_Operator(bpy.types.Operator):
-    """Load PROXY from asset library."""
+    """Load PROXY from asset library"""
     bl_idname = "mpfb.load_library_proxy"
     bl_label = "Load"
     bl_options = {'REGISTER', 'UNDO'}

--- a/src/mpfb/ui/assetlibrary/operators/loadlibraryskin.py
+++ b/src/mpfb/ui/assetlibrary/operators/loadlibraryskin.py
@@ -10,7 +10,7 @@ from mpfb import ClassManager
 _LOG = LogService.get_logger("assetlibrary.loadlibraryskin")
 
 class MPFB_OT_Load_Library_Skin_Operator(bpy.types.Operator):
-    """Load skin MHMAT from asset library."""
+    """Load skin MHMAT from asset library"""
     bl_idname = "mpfb.load_library_skin"
     bl_label = "Load"
     bl_options = {'REGISTER', 'UNDO'}

--- a/src/mpfb/ui/assetlibrary/operators/unloadlibraryclothes.py
+++ b/src/mpfb/ui/assetlibrary/operators/unloadlibraryclothes.py
@@ -11,7 +11,7 @@ from mpfb import ClassManager
 _LOG = LogService.get_logger("assetlibrary.unloadlibraryclothes")
 
 class MPFB_OT_Unload_Library_Clothes_Operator(bpy.types.Operator):
-    """Unequip mhclo asset that has been previously loaded."""
+    """Unequip mhclo asset that has been previously loaded"""
     bl_idname = "mpfb.unload_library_clothes"
     bl_label = "Unequip"
     bl_options = {'REGISTER', 'UNDO'}

--- a/src/mpfb/ui/assetlibrary/properties/makeclothes_metadata.json
+++ b/src/mpfb/ui/assetlibrary/properties/makeclothes_metadata.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "makeclothes_metadata",
-    "description": "Set MakeClothes specific metadata on the object, based on the contents of the MHCLO file. You only need this if you plan to work with the clothes in MakeClothes.",
+    "description": "Set MakeClothes specific metadata on the object, based on the contents of the MHCLO file. You only need this if you plan to work with the clothes in MakeClothes",
     "label": "MakeClothes metadata",
     "default": false
 }

--- a/src/mpfb/ui/assetlibrary/properties/material_instances.json
+++ b/src/mpfb/ui/assetlibrary/properties/material_instances.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "material_instances",
-    "description": "When using enhanced skin, also create instance for extra vertex groups and place them in material slots. This will mean the body will get for example both a body material and a fingernails material.",
+    "description": "When using enhanced skin, also create instance for extra vertex groups and place them in material slots. This will mean the body will get for example both a body material and a fingernails material",
     "label": "Material instances",
     "default": true
 }

--- a/src/mpfb/ui/assetlibrary/properties/procedural_eyes.json
+++ b/src/mpfb/ui/assetlibrary/properties/procedural_eyes.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "procedural_eyes",
-    "description": "Apply a procedural texture to the eyes rather than using the standard material.",
+    "description": "Apply a procedural texture to the eyes rather than using the standard material",
     "label": "Procedural eyes",
     "default": true
 }

--- a/src/mpfb/ui/assetlibrary/properties/skin_type.json
+++ b/src/mpfb/ui/assetlibrary/properties/skin_type.json
@@ -5,7 +5,7 @@
     "label": "Skin type",
     "default": "ENHANCED_SSS",
     "items": [
-		["MAKESKIN", "Standard material", "Use a standard (makeskin/mhmat) material. This is usually a plain diffuse texture with no extras.", 1],
+		["MAKESKIN", "Standard material", "Use a standard (makeskin/mhmat) material. This is usually a plain diffuse texture with no extras", 1],
 		["ENHANCED", "Enhanced skin material", "Enhanced skin material", 2],
 		["ENHANCED_SSS", "Enhanced skin with SSS", "Enhanced skin material with SSS", 3]
     ]

--- a/src/mpfb/ui/assetlibrary/properties/specific_delete_group.json
+++ b/src/mpfb/ui/assetlibrary/properties/specific_delete_group.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "specific_delete_group",
-    "description": "Create a specific delete group named after the clothes. If unchecked, the generic \"Delete\" group will be used.",
+    "description": "Create a specific delete group named after the clothes. If unchecked, the generic \"Delete\" group will be used",
     "label": "Specific delete group",
     "default": true
 }

--- a/src/mpfb/ui/basemeshops/operators/bakeshapekeys.py
+++ b/src/mpfb/ui/basemeshops/operators/bakeshapekeys.py
@@ -13,7 +13,7 @@ from bpy_extras.io_utils import ImportHelper
 _LOG = LogService.get_logger("basemeshops.operators.bakeshapekeys")
 
 class MPFB_OT_Bake_Shapekeys_Operator(bpy.types.Operator):
-    """Bake all shape keys into a final mesh. WARNING: You will no longer be able to adjust targets after doing this."""
+    """Bake all shape keys into a final mesh. WARNING: You will no longer be able to adjust targets after doing this"""
     bl_idname = "mpfb.bake_shapekeys"
     bl_label = "Bake shapekeys"
     bl_options = {'REGISTER', 'UNDO'}

--- a/src/mpfb/ui/basemeshops/operators/deletehelpers.py
+++ b/src/mpfb/ui/basemeshops/operators/deletehelpers.py
@@ -13,7 +13,7 @@ from bpy_extras.io_utils import ImportHelper
 _LOG = LogService.get_logger("basemeshops.operators.deletehelpers")
 
 class MPFB_OT_Delete_Helpers_Operator(bpy.types.Operator):
-    """Delete all helper geometry. This will also delete the mask operator for hiding helpers. WARNING: You will not be able to equip many clothes after doing this."""
+    """Delete all helper geometry. This will also delete the mask operator for hiding helpers. WARNING: You will not be able to equip many clothes after doing this"""
     bl_idname = "mpfb.delete_helpers"
     bl_label = "Delete helpers"
     bl_options = {'REGISTER', 'UNDO'}

--- a/src/mpfb/ui/developer/operators/loadweights.py
+++ b/src/mpfb/ui/developer/operators/loadweights.py
@@ -11,7 +11,7 @@ from bpy_extras.io_utils import ImportHelper
 _LOG = LogService.get_logger("developer.operators.loadweights")
 
 class MPFB_OT_Load_Weights_Operator(bpy.types.Operator, ImportHelper):
-    """Load weights from definition in json. NOTE that the base mesh must have the rig in question as a parent for this to work."""
+    """Load weights from definition in json. NOTE that the base mesh must have the rig in question as a parent for this to work"""
     bl_idname = "mpfb.load_weights"
     bl_label = "Load weights"
     bl_options = {'REGISTER', 'UNDO'}

--- a/src/mpfb/ui/developer/operators/resetloglevels.py
+++ b/src/mpfb/ui/developer/operators/resetloglevels.py
@@ -8,7 +8,7 @@ _LOG = LogService.get_logger("loglevels.operators.resetloglevels")
 
 
 class MPFB_OT_Reset_Log_Levels_Operator(bpy.types.Operator):
-    """Reset log levels to the default. This will remove all log level overrides."""
+    """Reset log levels to the default. This will remove all log level overrides"""
     bl_idname = "mpfb.reset_log_levels"
     bl_label = "Reset log levels"
     bl_options = {'REGISTER'}

--- a/src/mpfb/ui/developer/operators/setloglevel.py
+++ b/src/mpfb/ui/developer/operators/setloglevel.py
@@ -8,7 +8,7 @@ _LOG = LogService.get_logger("loglevels.operators.setloglevel")
 
 
 class MPFB_OT_Set_Log_Level_Operator(bpy.types.Operator):
-    """Set a log level override for a channel. If the "default" channel is selected, set the default log level."""
+    """Set a log level override for a channel. If the "default" channel is selected, set the default log level"""
     bl_idname = "mpfb.set_log_level"
     bl_label = "Set log level"
     bl_options = {'REGISTER'}

--- a/src/mpfb/ui/importer/importerpanel.py
+++ b/src/mpfb/ui/importer/importerpanel.py
@@ -49,7 +49,7 @@ IMPORTER_PROPERTIES.add_property(_PRESETS_LIST_PROP, _populate_presets)
 _SKIN_SETTINGS_LIST_PROP = {
     "type": "enum",
     "name": "skin_settings_for_import",
-    "description": "Skin material settings to use when importing a human. These are created on the material tab.",
+    "description": "Skin material settings to use when importing a human. These are created on the material tab",
     "label": "Skin settings to use",
     "default": 0
 }
@@ -58,7 +58,7 @@ IMPORTER_PROPERTIES.add_property(_SKIN_SETTINGS_LIST_PROP, _populate_skin_settin
 _EYE_SETTINGS_LIST_PROP = {
     "type": "enum",
     "name": "eye_settings_for_import",
-    "description": "Eye material settings to use when importing a human. These are created on the material tab.",
+    "description": "Eye material settings to use when importing a human. These are created on the material tab",
     "label": "Eye settings to use",
     "default": 0
 }

--- a/src/mpfb/ui/importerpresets/properties/collections_as_children.json
+++ b/src/mpfb/ui/importerpresets/properties/collections_as_children.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "collections_as_children",
-    "description": "Create new collections as sub-collections of the currently active collection.",
+    "description": "Create new collections as sub-collections of the currently active collection",
     "label": "Collections as children",
     "default": false
 }

--- a/src/mpfb/ui/importerpresets/properties/extra_vertex_groups.json
+++ b/src/mpfb/ui/importerpresets/properties/extra_vertex_groups.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "extra_vertex_groups",
-    "description": "Normaly the base mesh and the proxy will only have one vertex group for the entire body. You can opt for creating more detailed vertex groups, such as lips, fingernails and so on. This is required for detailed materials.",
+    "description": "Normaly the base mesh and the proxy will only have one vertex group for the entire body. You can opt for creating more detailed vertex groups, such as lips, fingernails and so on. This is required for detailed materials",
     "label": "Extra vertex groups",
     "default": true
 }

--- a/src/mpfb/ui/importerpresets/properties/feet_on_ground.json
+++ b/src/mpfb/ui/importerpresets/properties/feet_on_ground.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "feet_on_ground",
-    "description": "Move the imported character along the z axis so that the lowest vertex of the base mesh is placed on z=0. This will not take clothes such as high heels into account.",
+    "description": "Move the imported character along the z axis so that the lowest vertex of the base mesh is placed on z=0. This will not take clothes such as high heels into account",
     "label": "Place feet on ground",
     "default": true
 }

--- a/src/mpfb/ui/importerpresets/properties/material_instances.json
+++ b/src/mpfb/ui/importerpresets/properties/material_instances.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "material_instances",
-    "description": "When using enhanced skin, also create instance for extra vertex groups and place them in material slots. This will mean the body will get for example both a body material and a fingernails material.",
+    "description": "When using enhanced skin, also create instance for extra vertex groups and place them in material slots. This will mean the body will get for example both a body material and a fingernails material",
     "label": "Material instances",
     "default": true
 }

--- a/src/mpfb/ui/importerpresets/properties/procedural_eyes.json
+++ b/src/mpfb/ui/importerpresets/properties/procedural_eyes.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "procedural_eyes",
-    "description": "Apply a procedural texture to the eyes rather than using the standard material.",
+    "description": "Apply a procedural texture to the eyes rather than using the standard material",
     "label": "Procedural eyes",
     "default": true
 }

--- a/src/mpfb/ui/importerpresets/properties/rig_as_parent.json
+++ b/src/mpfb/ui/importerpresets/properties/rig_as_parent.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "import_rig",
-    "description": "Import the armature/rig. This requires that you have selected one in MakeHuman.",
+    "description": "Import the armature/rig. This requires that you have selected one in MakeHuman",
     "label": "Import rig",
     "default": true
 }

--- a/src/mpfb/ui/importerpresets/properties/scale_factor.json
+++ b/src/mpfb/ui/importerpresets/properties/scale_factor.json
@@ -1,7 +1,7 @@
 {
     "type": "enum",
     "name": "scale_factor",
-    "description": "The overall scale of the human, calculated as what equals one blender unit.",
+    "description": "The overall scale of the human, calculated as what equals one blender unit",
     "label": "Scale factor",
     "default": "METER",
     "items": [

--- a/src/mpfb/ui/loadclothes/operators/loadclothes.py
+++ b/src/mpfb/ui/loadclothes/operators/loadclothes.py
@@ -15,7 +15,7 @@ from mpfb import ClassManager
 _LOG = LogService.get_logger("loadclothes.loadclothes")
 
 class MPFB_OT_Load_Clothes_Operator(bpy.types.Operator, ImportHelper):
-    """Load clothes from MHCLO file."""
+    """Load clothes from MHCLO file"""
     bl_idname = "mpfb.load_clothes"
     bl_label = "Load clothes from file"
     bl_options = {'REGISTER', 'UNDO'}

--- a/src/mpfb/ui/loadclothes/properties/makeclothes_metadata.json
+++ b/src/mpfb/ui/loadclothes/properties/makeclothes_metadata.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "makeclothes_metadata",
-    "description": "Set MakeClothes specific metadata on the object, based on the contents of the MHCLO file. You only need this if you plan to work with the clothes in MakeClothes.",
+    "description": "Set MakeClothes specific metadata on the object, based on the contents of the MHCLO file. You only need this if you plan to work with the clothes in MakeClothes",
     "label": "MakeClothes metadata",
     "default": false
 }

--- a/src/mpfb/ui/loadclothes/properties/material_type.json
+++ b/src/mpfb/ui/loadclothes/properties/material_type.json
@@ -7,7 +7,7 @@
     "items": [
     	["NONE", "No material", "Do not assign a material to the imported mesh", 0],
 		["PRINCIPLED", "Principled", "A simple one-color principled material", 1],
-		["MAKESKIN", "Standard material", "Use a standard (makeskin/mhmat) material. This is probably what you want.", 2],
+		["MAKESKIN", "Standard material", "Use a standard (makeskin/mhmat) material. This is probably what you want", 2],
 		["ENHANCED", "Enhanced skin material", "Enhanced skin material", 3],
 		["ENHANCED_SSS", "Enhanced skin with SSS", "Enhanced skin material with SSS", 4],
 		["PROCEDURAL_EYES", "Procedural eyes", "Procedural eyes material", 5]

--- a/src/mpfb/ui/loadclothes/properties/specific_delete_group.json
+++ b/src/mpfb/ui/loadclothes/properties/specific_delete_group.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "specific_delete_group",
-    "description": "Create a specific delete group named after the clothes. If unchecked, the generic \"Delete\" group will be used.",
+    "description": "Create a specific delete group named after the clothes. If unchecked, the generic \"Delete\" group will be used",
     "label": "Specific delete group",
     "default": true
 }

--- a/src/mpfb/ui/makeclothes/objectproperties/author.json
+++ b/src/mpfb/ui/makeclothes/objectproperties/author.json
@@ -1,7 +1,7 @@
 {
     "type": "string",
     "name": "author",
-    "description": "The author of these clothes. This will have little practical effect apart from being written to the mhmat file.",
+    "description": "The author of these clothes. This will have little practical effect apart from being written to the mhmat file",
     "label": "Author",
     "default": "",
     "aliases": ["MhClothesAuthor"]

--- a/src/mpfb/ui/makeclothes/objectproperties/description.json
+++ b/src/mpfb/ui/makeclothes/objectproperties/description.json
@@ -1,7 +1,7 @@
 {
     "type": "string",
     "name": "description",
-    "description": "A description of these clothes. It will have little practical effect apart from being written to the mhclo file.",
+    "description": "A description of these clothes. It will have little practical effect apart from being written to the mhclo file",
     "label": "Description",
     "default": "",
     "aliases": ["MhClothesDesc"]

--- a/src/mpfb/ui/makeclothes/objectproperties/homepage.json
+++ b/src/mpfb/ui/makeclothes/objectproperties/homepage.json
@@ -1,7 +1,7 @@
 {
     "type": "string",
     "name": "homepage",
-    "description": "The home page of these clothes, if any. This will have little practical effect apart from being written to the mhclo file.",
+    "description": "The home page of these clothes, if any. This will have little practical effect apart from being written to the mhclo file",
     "label": "Homepage",
     "default": "",
     "aliases": ["MhMcHomepage"]

--- a/src/mpfb/ui/makeclothes/objectproperties/license.json
+++ b/src/mpfb/ui/makeclothes/objectproperties/license.json
@@ -1,7 +1,7 @@
 {
     "type": "enum",
     "name": "license",
-    "description": "Set an output license for the clothes. This will have no practical effect apart from being included in the written MHCLO file.",
+    "description": "Set an output license for the clothes. This will have no practical effect apart from being included in the written MHCLO file",
     "label": "License",
     "default": "CC0",
     "items": [

--- a/src/mpfb/ui/makeclothes/objectproperties/name.json
+++ b/src/mpfb/ui/makeclothes/objectproperties/name.json
@@ -1,7 +1,7 @@
 {
     "type": "string",
     "name": "name",
-    "description": "The name of this material. This name is used for exports e.g. with mhx2.",
+    "description": "The name of this material. This name is used for exports e.g. with mhx2",
     "label": "Name",
     "default": "new_clothes",
     "aliases": ["MhClothesName"]

--- a/src/mpfb/ui/makeclothes/objectproperties/tag.json
+++ b/src/mpfb/ui/makeclothes/objectproperties/tag.json
@@ -1,7 +1,7 @@
 {
     "type": "string",
     "name": "tag",
-    "description": "A category these clothes fit into, for example \"dress\" or \"female\". This will influence sorting and filtering in MH.",
+    "description": "A category these clothes fit into, for example \"dress\" or \"female\". This will influence sorting and filtering in MH",
     "label": "Tag",
     "default": "",
     "aliases": ["MhClothesTags"]

--- a/src/mpfb/ui/makeclothes/objectproperties/z_depth.json
+++ b/src/mpfb/ui/makeclothes/objectproperties/z_depth.json
@@ -1,7 +1,7 @@
 {
     "type": "int",
     "name": "z_depth",
-    "description": "The order value of the clothes, for if several pieces of clothes are on top of each other.",
+    "description": "The order value of the clothes, for if several pieces of clothes are on top of each other",
     "label": "Z Depth",
     "default": 50,
     "aliases": ["MhZDepth"]

--- a/src/mpfb/ui/makeskin/objectproperties/alpha_to_coverage.json
+++ b/src/mpfb/ui/makeskin/objectproperties/alpha_to_coverage.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "alpha_to_coverage",
-    "description": "Use A2C hardware acceleration for rendering transparency in this material. This is only relevant inside MH.",
+    "description": "Use A2C hardware acceleration for rendering transparency in this material. This is only relevant inside MH",
     "label": "A2C acceleration",
     "default": true,
     "aliases": [ "alphaToCoverage", "MhMsAlphaToCoverage" ]

--- a/src/mpfb/ui/makeskin/objectproperties/author.json
+++ b/src/mpfb/ui/makeskin/objectproperties/author.json
@@ -1,7 +1,7 @@
 {
     "type": "string",
     "name": "author",
-    "description": "The author of this material. This will have little practical effect apart from being written to the mhmat file.",
+    "description": "The author of this material. This will have little practical effect apart from being written to the mhmat file",
     "label": "Author",
     "default": "",
     "aliases": ["MhMsAuthor"]

--- a/src/mpfb/ui/makeskin/objectproperties/auto_blend.json
+++ b/src/mpfb/ui/makeskin/objectproperties/auto_blend.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "auto_blend",
-    "description": "Autoadjust lit sphere and diffuse color to match skin tone.",
+    "description": "Autoadjust lit sphere and diffuse color to match skin tone",
     "label": "Adjust lit sphere",
     "default": false,
     "aliases": ["autoBlendSkin", "MhMsAutoBlend"]

--- a/src/mpfb/ui/makeskin/objectproperties/backface_culling.json
+++ b/src/mpfb/ui/makeskin/objectproperties/backface_culling.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "backface_culling",
-    "description": "If the back side of faces with the material should be invisible. This has no effect in exports, but may be important in MH.",
+    "description": "If the back side of faces with the material should be invisible. This has no effect in exports, but may be important in MH",
     "label": "Backface culling",
     "default": true,
     "aliases": ["backfaceCull", "MhMsBackfaceCull"] 

--- a/src/mpfb/ui/makeskin/objectproperties/cast_shadows.json
+++ b/src/mpfb/ui/makeskin/objectproperties/cast_shadows.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "cast_shadows",
-    "description": "If the material casts shadows. This has no effect in exports.",
+    "description": "If the material casts shadows. This has no effect in exports",
     "label": "Cast shadows",
     "default": true,
     "aliases": [ "castShadows", "MhMsCastShadows" ]

--- a/src/mpfb/ui/makeskin/objectproperties/depthless.json
+++ b/src/mpfb/ui/makeskin/objectproperties/depthless.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "depthless",
-    "description": "If the material is to be rendered as having no depth. It is unlikely you want this.",
+    "description": "If the material is to be rendered as having no depth. It is unlikely you want this",
     "label": "Depthless",
     "default": false,
     "aliases": ["MhMsDepthless"]

--- a/src/mpfb/ui/makeskin/objectproperties/description.json
+++ b/src/mpfb/ui/makeskin/objectproperties/description.json
@@ -1,7 +1,7 @@
 {
     "type": "string",
     "name": "description",
-    "description": "A description of the material. It will have little practical effect apart from being written to the mhmat file.",
+    "description": "A description of the material. It will have little practical effect apart from being written to the mhmat file",
     "label": "Description",
     "default": "",
     "aliases": ["MhMsDescription"]

--- a/src/mpfb/ui/makeskin/objectproperties/homepage.json
+++ b/src/mpfb/ui/makeskin/objectproperties/homepage.json
@@ -1,7 +1,7 @@
 {
     "type": "string",
     "name": "homepage",
-    "description": "The home page of the material, if any. This will have little practical effect apart from being written to the mhmat file.",
+    "description": "The home page of the material, if any. This will have little practical effect apart from being written to the mhmat file",
     "label": "Homepage",
     "default": "",
     "aliases": ["MhMsHomepage"]

--- a/src/mpfb/ui/makeskin/objectproperties/license.json
+++ b/src/mpfb/ui/makeskin/objectproperties/license.json
@@ -1,7 +1,7 @@
 {
     "type": "enum",
     "name": "license",
-    "description": "Set an output license for the material. This will have no practical effect apart from being included in the written MHMAT file.",
+    "description": "Set an output license for the material. This will have no practical effect apart from being included in the written MHMAT file",
     "label": "License",
     "default": "CC0",
     "items": [

--- a/src/mpfb/ui/makeskin/objectproperties/litsphere.json
+++ b/src/mpfb/ui/makeskin/objectproperties/litsphere.json
@@ -1,12 +1,12 @@
 {
     "type": "enum",
     "name": "litsphere",
-    "description": "A litsphere texture is used for emulate lighting and reflections inside MakeHuman. It thus has no effect outside MakeHuman. For any clothing (not just leather), you will want to use the \"leather\" litsphere.",
+    "description": "A litsphere texture is used for emulate lighting and reflections inside MakeHuman. It thus has no effect outside MakeHuman. For any clothing (not just leather), you will want to use the \"leather\" litsphere",
     "label": "Litsphere",
     "default": "lit_leather",
     "items": [
-		["lit_leather", "leather", "Leather litsphere. This is appropriate for all clothes, not only leather.", 1],
-		["lit_standard_skin", "standard skin", "Standard skin litsphere. This is appropriate for all skins.", 2],
+		["lit_leather", "leather", "Leather litsphere. This is appropriate for all clothes, not only leather", 1],
+		["lit_standard_skin", "standard skin", "Standard skin litsphere. This is appropriate for all skins", 2],
 		["lit_african", "african skin", "African skin litsphere", 3],
 		["lit_asian", "asian skin", "Asian skin litsphere", 4],
 		["lit_caucasian", "caucasian skin", "Caucasian skin litsphere", 5],

--- a/src/mpfb/ui/makeskin/objectproperties/name.json
+++ b/src/mpfb/ui/makeskin/objectproperties/name.json
@@ -1,7 +1,7 @@
 {
     "type": "string",
     "name": "name",
-    "description": "The name of this material. This name is used for exports e.g. with mhx2.",
+    "description": "The name of this material. This name is used for exports e.g. with mhx2",
     "label": "Name",
     "default": "new_material",
     "aliases": ["MhMsName"]

--- a/src/mpfb/ui/makeskin/objectproperties/receive_shadows.json
+++ b/src/mpfb/ui/makeskin/objectproperties/receive_shadows.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "receive_shadows",
-    "description": "CIf the material receives shadows. This has no effect in exports.",
+    "description": "If the material receives shadows. This has no effect in exports",
     "label": "Receive shadows",
     "default": true,
     "aliases": ["receiveShadows", "MhMsReceiveShadows"]

--- a/src/mpfb/ui/makeskin/objectproperties/shadeless.json
+++ b/src/mpfb/ui/makeskin/objectproperties/shadeless.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "shadeless",
-    "description": "If the material is shadeless. It is unlikely you want this.",
+    "description": "If the material is shadeless. It is unlikely you want this",
     "label": "Shadeless",
     "default": false,
     "aliases": ["MhMsShadeless"]

--- a/src/mpfb/ui/makeskin/objectproperties/sss_enable.json
+++ b/src/mpfb/ui/makeskin/objectproperties/sss_enable.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "sss_enable",
-    "description": "If the material is to be rendered with sub surface scattering. This is not implemented in MH, but might have an effect on exports.",
+    "description": "If the material is to be rendered with sub surface scattering. This is not implemented in MH, but might have an effect on exports",
     "label": "Subsurface scattering",
     "default": false,
     "aliases": ["MhMsSSSEnable", "sssEnabled"]

--- a/src/mpfb/ui/makeskin/objectproperties/tag.json
+++ b/src/mpfb/ui/makeskin/objectproperties/tag.json
@@ -1,7 +1,7 @@
 {
     "type": "string",
     "name": "tag",
-    "description": "A category the material fits into, for example \"blond\" or \"female\". This will influence sorting and filtering in MH.",
+    "description": "A category the material fits into, for example \"blond\" or \"female\". This will influence sorting and filtering in MH",
     "label": "Tag",
     "default": "",
     "aliases": ["MhMsTag"]

--- a/src/mpfb/ui/makeskin/objectproperties/textures.json
+++ b/src/mpfb/ui/makeskin/objectproperties/textures.json
@@ -1,7 +1,7 @@
 {
     "type": "enum",
     "name": "textures",
-    "description": "How do we handle texture file names and paths? Unless you know what you are doing, you will want to use normalize. This will copy all images to an appropriate location with an appropriate filename, valid for uploading to the asset repository.",
+    "description": "How do we handle texture file names and paths? Unless you know what you are doing, you will want to use normalize. This will copy all images to an appropriate location with an appropriate filename, valid for uploading to the asset repository",
     "label": "Textures",
     "default": "NORMALIZE",
     "items": [

--- a/src/mpfb/ui/makeskin/objectproperties/transparent.json
+++ b/src/mpfb/ui/makeskin/objectproperties/transparent.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "transparent",
-    "description": "Use transparent, when you expect that your object will be in front of another transparent object. Using the alpha-channel, MakeHuman is internally only able to render one transparent layer. Use this and switch backface culling off, when you create transparent hair.",
+    "description": "Use transparent, when you expect that your object will be in front of another transparent object. Using the alpha-channel, MakeHuman is internally only able to render one transparent layer. Use this and switch backface culling off, when you create transparent hair",
     "label": "Transparent",
     "default": false,
     "aliases": ["MhMsTransparent"]

--- a/src/mpfb/ui/makeskin/objectproperties/wireframe.json
+++ b/src/mpfb/ui/makeskin/objectproperties/wireframe.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "wireframe",
-    "description": "If the material is to be rendered as a wireframe. It is unlikely you want this.",
+    "description": "If the material is to be rendered as a wireframe. It is unlikely you want this",
     "label": "Wireframe",
     "default": false,
     "aliases": ["MhMsWireframe"]

--- a/src/mpfb/ui/maketarget/operators/writetarget.py
+++ b/src/mpfb/ui/maketarget/operators/writetarget.py
@@ -13,7 +13,7 @@ from mpfb import ClassManager
 _LOG = LogService.get_logger("maketarget.writetarget")
 
 class MPFB_OT_WriteTargetOperator(bpy.types.Operator, ExportHelper):
-    """Write target to target file. In order to do this, you must first have created a primary target on the mesh."""
+    """Write target to target file. In order to do this, you must first have created a primary target on the mesh"""
     bl_idname = "mpfb.write_maketarget_target"
     bl_label = "Save target"
     bl_options = {'REGISTER'}

--- a/src/mpfb/ui/model/_macrosubpanel.py
+++ b/src/mpfb/ui/model/_macrosubpanel.py
@@ -7,6 +7,7 @@ from mpfb.services.logservice import LogService
 from mpfb.services.locationservice import LocationService
 from mpfb.services.objectservice import ObjectService
 from mpfb.services.targetservice import TargetService
+from mpfb.services.uiservice import UiService
 from mpfb.entities.objectproperties import HumanObjectProperties
 
 _LOG = LogService.get_logger("model.macrosubpanel")
@@ -43,6 +44,7 @@ class MPFB_PT_Macro_Sub_Panel(bpy.types.Panel):
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_parent_id = "MPFB_PT_Model_Panel"
+    bl_category = UiService.get_value("MODELCATEGORY")
     bl_options = {'DEFAULT_CLOSED'}
 
     def _draw_category(self, scene, layout, category_name, targets, basemesh):

--- a/src/mpfb/ui/model/_modelsubpanels.py
+++ b/src/mpfb/ui/model/_modelsubpanels.py
@@ -43,10 +43,10 @@ class _Abstract_Model_Panel(bpy.types.Panel):
             _LOG.debug("No image for ", category["name"])
 
         if category["has_left_and_right"]:
-            box.prop(scene, self.section_name + ".l-" + category["name"], text="Left:")
-            box.prop(scene, self.section_name + ".r-" + category["name"], text="Right:")
+            box.prop(scene, UiService.as_valid_identifier(self.section_name + ".l-" + category["name"]), text="Left:")
+            box.prop(scene, UiService.as_valid_identifier(self.section_name + ".r-" + category["name"]), text="Right:")
         else:
-            box.prop(scene, self.section_name + "." + category["name"], text="Value:")
+            box.prop(scene, UiService.as_valid_identifier(self.section_name + "." + category["name"]), text="Value:")
 
     def draw(self, context):
         _LOG.enter()
@@ -181,9 +181,9 @@ for name in _sections:
     for _category in _section["categories"]:
         _LOG.debug("_category", _category)
 
-        _unsided_name = name + "." + _category["name"]
-        _left_name = name + ".l-" + _category["name"]
-        _right_name = name + ".r-" + _category["name"]
+        _unsided_name = UiService.as_valid_identifier(name + "." + _category["name"])
+        _left_name = UiService.as_valid_identifier(name + ".l-" + _category["name"])
+        _right_name = UiService.as_valid_identifier(name + ".r-" + _category["name"])
 
         _LOG.debug("names", (_unsided_name, _left_name, _right_name))
 

--- a/src/mpfb/ui/model/_modelsubpanels.py
+++ b/src/mpfb/ui/model/_modelsubpanels.py
@@ -20,7 +20,7 @@ _TARGETS_JSON = os.path.join(_TARGETS_DIR, "target.json")
 _LOG.debug("Targets json:", _TARGETS_JSON)
 
 class _Abstract_Model_Panel(bpy.types.Panel):
-    """Human modeling panel."""
+    """Human modeling panel"""
 
     bl_label = "SHOULD BE OVERRIDDEN"
     bl_space_type = "VIEW_3D"

--- a/src/mpfb/ui/model/_modelsubpanels.py
+++ b/src/mpfb/ui/model/_modelsubpanels.py
@@ -41,10 +41,10 @@ class _Abstract_Model_Panel(bpy.types.Panel):
             _LOG.debug("No image for ", category["name"])
 
         if category["has_left_and_right"]:
-            box.prop(scene, self.section_name + ".l-" + category["name"], text="Left:")
-            box.prop(scene, self.section_name + ".r-" + category["name"], text="Right:")
+            box.prop(scene, str(self.section_name + ".l-" + category["name"]).replace("-", "_"), text="Left:")
+            box.prop(scene, str(self.section_name + ".r-" + category["name"]).replace("-", "_"), text="Right:")
         else:
-            box.prop(scene, self.section_name + "." + category["name"], text="Value:")
+            box.prop(scene, str(self.section_name + "." + category["name"]).replace("-", "_"), text="Value:")
 
     def draw(self, context):
         _LOG.enter()
@@ -179,9 +179,9 @@ for name in _sections:
     for _category in _section["categories"]:
         _LOG.debug("_category", _category)
 
-        _unsided_name = name + "." + _category["name"]
-        _left_name = name + ".l-" + _category["name"]
-        _right_name = name + ".r-" + _category["name"]
+        _unsided_name = str(name + "." + _category["name"]).replace("-", "_")
+        _left_name = str(name + ".l-" + _category["name"]).replace("-", "_")
+        _right_name = str(name + ".r-" + _category["name"]).replace("-", "_")
 
         _LOG.debug("names", (_unsided_name, _left_name, _right_name))
 

--- a/src/mpfb/ui/model/_modelsubpanels.py
+++ b/src/mpfb/ui/model/_modelsubpanels.py
@@ -43,10 +43,10 @@ class _Abstract_Model_Panel(bpy.types.Panel):
             _LOG.debug("No image for ", category["name"])
 
         if category["has_left_and_right"]:
-            box.prop(scene, str(self.section_name + ".l-" + category["name"]).replace("-", "_"), text="Left:")
-            box.prop(scene, str(self.section_name + ".r-" + category["name"]).replace("-", "_"), text="Right:")
+            box.prop(scene, self.section_name + ".l-" + category["name"], text="Left:")
+            box.prop(scene, self.section_name + ".r-" + category["name"], text="Right:")
         else:
-            box.prop(scene, str(self.section_name + "." + category["name"]).replace("-", "_"), text="Value:")
+            box.prop(scene, self.section_name + "." + category["name"], text="Value:")
 
     def draw(self, context):
         _LOG.enter()
@@ -181,9 +181,9 @@ for name in _sections:
     for _category in _section["categories"]:
         _LOG.debug("_category", _category)
 
-        _unsided_name = str(name + "." + _category["name"]).replace("-", "_")
-        _left_name = str(name + ".l-" + _category["name"]).replace("-", "_")
-        _right_name = str(name + ".r-" + _category["name"]).replace("-", "_")
+        _unsided_name = name + "." + _category["name"]
+        _left_name = name + ".l-" + _category["name"]
+        _right_name = name + ".r-" + _category["name"]
 
         _LOG.debug("names", (_unsided_name, _left_name, _right_name))
 

--- a/src/mpfb/ui/model/_modelsubpanels.py
+++ b/src/mpfb/ui/model/_modelsubpanels.py
@@ -8,6 +8,7 @@ from mpfb.services.locationservice import LocationService
 from mpfb.services.objectservice import ObjectService
 from mpfb.services.targetservice import TargetService
 from mpfb.services.assetservice import AssetService
+from mpfb.services.uiservice import UiService
 
 from ._modelingicons import MODELING_ICONS
 
@@ -25,6 +26,7 @@ class _Abstract_Model_Panel(bpy.types.Panel):
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_parent_id = "MPFB_PT_Model_Panel"
+    bl_category = UiService.get_value("MODELCATEGORY")
     bl_options = {'DEFAULT_CLOSED'}
 
     section = dict()

--- a/src/mpfb/ui/model/operators/refithuman.py
+++ b/src/mpfb/ui/model/operators/refithuman.py
@@ -9,7 +9,7 @@ from mpfb import ClassManager
 _LOG = LogService.get_logger("model.refithuman")
 
 class MPFB_OT_RefitHumanOperator(bpy.types.Operator):
-    """Refit clothes, bodyparts, proxy and rig to the basemesh. This is needed if you have changed modeling sliders after having added such assets."""
+    """Refit clothes, bodyparts, proxy and rig to the basemesh. This is needed if you have changed modeling sliders after having added such assets"""
     bl_idname = "mpfb.refit_human"
     bl_label = "Refit assets to basemesh"
     bl_options = {'REGISTER', 'UNDO'}

--- a/src/mpfb/ui/newhuman/properties/add_breast.json
+++ b/src/mpfb/ui/newhuman/properties/add_breast.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "add_breast",
-    "description": "Add breast macrodetails to the created human. This will be ignored if phenotype is disabled above.",
+    "description": "Add breast macrodetails to the created human. This will be ignored if phenotype is disabled above",
     "label": "Add breast targets",
     "default": true
 }

--- a/src/mpfb/ui/newhuman/properties/add_phenotype.json
+++ b/src/mpfb/ui/newhuman/properties/add_phenotype.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "add_phenotype",
-    "description": "Add a phenotype to the created human. You can add additional phenotype traits later on.",
+    "description": "Add a phenotype to the created human. You can add additional phenotype traits later on",
     "label": "Add phenotype",
     "default": true
 }

--- a/src/mpfb/ui/newhuman/properties/breast_influence.json
+++ b/src/mpfb/ui/newhuman/properties/breast_influence.json
@@ -1,7 +1,7 @@
 {
     "type": "float",
     "name": "breast_influence",
-    "description": "Initial strength of breast target. This can be changed under shape keys later.",
+    "description": "Initial strength of breast target. This can be changed under shape keys later",
     "label": "Breast influence",
     "default": 0.1,
     "max": 1.0,

--- a/src/mpfb/ui/newhuman/properties/extra_vertex_groups.json
+++ b/src/mpfb/ui/newhuman/properties/extra_vertex_groups.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "extra_vertex_groups",
-    "description": "Normaly the base mesh will only have one vertex group for the entire body. You can opt for creating more detailed vertex groups, such as lips, fingernails and so on. This is required for detailed materials.",
+    "description": "Normaly the base mesh will only have one vertex group for the entire body. You can opt for creating more detailed vertex groups, such as lips, fingernails and so on. This is required for detailed materials",
     "label": "Extra vertex groups",
     "default": true
 }

--- a/src/mpfb/ui/newhuman/properties/phenotype_influence.json
+++ b/src/mpfb/ui/newhuman/properties/phenotype_influence.json
@@ -1,7 +1,7 @@
 {
     "type": "float",
     "name": "phenotype_influence",
-    "description": "Initial strength of phenotype targets. This can be changed in the modeling panel later.",
+    "description": "Initial strength of phenotype targets. This can be changed in the modeling panel later",
     "label": "Phenotype influence",
     "default": 1.0,
     "max": 1.0,

--- a/src/mpfb/ui/newhuman/properties/scale_factor.json
+++ b/src/mpfb/ui/newhuman/properties/scale_factor.json
@@ -1,7 +1,7 @@
 {
     "type": "enum",
     "name": "scale_factor",
-    "description": "The overall scale of the human, calculated as what equals one blender unit.",
+    "description": "The overall scale of the human, calculated as what equals one blender unit",
     "label": "Scale factor",
     "default": "METER",
     "items": [

--- a/src/mpfb/ui/poseops/operators/apply_pose.py
+++ b/src/mpfb/ui/poseops/operators/apply_pose.py
@@ -11,7 +11,7 @@ from mpfb import ClassManager
 _LOG = LogService.get_logger("poseops.apply_pose")
 
 class MPFB_OT_Apply_Pose_Operator(bpy.types.Operator):
-    """Apply pose as rest pose. WARNING: This will also bake all shape keys and make it impossible to do further modeling."""
+    """Apply pose as rest pose. WARNING: This will also bake all shape keys and make it impossible to do further modeling"""
     bl_idname = "mpfb.apply_pose"
     bl_label = "Apply as rest pose"
     bl_options = {'REGISTER', 'UNDO'}

--- a/src/mpfb/ui/poseops/operators/copy_pose.py
+++ b/src/mpfb/ui/poseops/operators/copy_pose.py
@@ -12,7 +12,7 @@ from mpfb import ClassManager
 _LOG = LogService.get_logger("poseops.copy_pose")
 
 class MPFB_OT_Copy_Pose_Operator(bpy.types.Operator):
-    """Copy pose from active to selected. Ie, first select all targets, then select the source. You can copy to multiple targets at the same time."""
+    """Copy pose from active to selected. Ie, first select all targets, then select the source. You can copy to multiple targets at the same time"""
     bl_idname = "mpfb.copy_pose"
     bl_label = "Copy pose"
     bl_options = {'REGISTER', 'UNDO'}

--- a/src/mpfb/ui/poseops/properties/only_rotation.json
+++ b/src/mpfb/ui/poseops/properties/only_rotation.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "only_rotation",
-    "description": "Only copy rotations, ie skip translate and scale changes. This is probably what you want for an FK rig.",
+    "description": "Only copy rotations, ie skip translate and scale changes. This is probably what you want for an FK rig",
     "label": "Only rotation",
     "default": true
 }

--- a/src/mpfb/ui/righelpers/properties/preserve_fk.json
+++ b/src/mpfb/ui/righelpers/properties/preserve_fk.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "preserve_fk",
-    "description": "Try to preserve as much of the current pose as possible when adding helpers. If unchecked, the bones will be set to rest pose before helpers are added.",
+    "description": "Try to preserve as much of the current pose as possible when adding helpers. If unchecked, the bones will be set to rest pose before helpers are added",
     "label": "Preserve pose",
     "default": true
 }

--- a/src/mpfb/ui/rigify/properties/keep_meta.json
+++ b/src/mpfb/ui/rigify/properties/keep_meta.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "keep_meta",
-    "description": "Do not delete the meta rig after producing.",
+    "description": "Do not delete the meta rig after producing",
     "label": "Keep meta rig",
     "default": false
 }

--- a/src/mpfb/ui/rigify/properties/produce.json
+++ b/src/mpfb/ui/rigify/properties/produce.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "produce",
-    "description": "After converting the rig to a rigify meta rig, also run the produce step to produce the final rig.",
+    "description": "After converting the rig to a rigify meta rig, also run the produce step to produce the final rig",
     "label": "Produce",
     "default": true
 }

--- a/src/mpfb/ui/sculpt/operators/setupsculpt.py
+++ b/src/mpfb/ui/sculpt/operators/setupsculpt.py
@@ -13,7 +13,7 @@ from bpy_extras.io_utils import ImportHelper
 _LOG = LogService.get_logger("sculpt.operators.setupsculpt")
 
 class MPFB_OT_Setup_Sculpt_Operator(bpy.types.Operator):
-    """Bake all shape keys into a final mesh and optionally perform other operations suitable for starting a sculpt project. WARNING: You will no longer be able to adjust targets after doing this."""
+    """Bake all shape keys into a final mesh and optionally perform other operations suitable for starting a sculpt project. WARNING: You will no longer be able to adjust targets after doing this"""
     bl_idname = "mpfb.setup_sculpt"
     bl_label = "Set up mesh for sculpt"
     bl_options = {'REGISTER', 'UNDO'}

--- a/src/mpfb/ui/sculpt/properties/apply_armature.json
+++ b/src/mpfb/ui/sculpt/properties/apply_armature.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "apply_armature",
-    "description": "This will apply the armature modifier on copies, effectively baking the pose.",
+    "description": "This will apply the armature modifier on copies, effectively baking the pose",
     "label": "Apply armature",
     "default": true
 }

--- a/src/mpfb/ui/sculpt/properties/hide_origin.json
+++ b/src/mpfb/ui/sculpt/properties/hide_origin.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "hide_origin",
-    "description": "Hide original character, only keeping copy/copies. This also hides clothes, body parts and armature.",
+    "description": "Hide original character, only keeping copy/copies. This also hides clothes, body parts and armature",
     "label": "Hide original character",
     "default": true
 }

--- a/src/mpfb/ui/sculpt/properties/hide_related.json
+++ b/src/mpfb/ui/sculpt/properties/hide_related.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "hide_related",
-    "description": "Hide related meshes, such as clothes, hair, teeth and eyes.",
+    "description": "Hide related meshes, such as clothes, hair, teeth and eyes",
     "label": "Hide related meshes",
     "default": true
 }

--- a/src/mpfb/ui/sculpt/properties/remove_delete.json
+++ b/src/mpfb/ui/sculpt/properties/remove_delete.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "remove_delete",
-    "description": "Remove delete groups. This will both clear the vertex groups and remove the mask modifiers. This will also clear the 'hide base mesh' modifier if present.",
+    "description": "Remove delete groups. This will both clear the vertex groups and remove the mask modifiers. This will also clear the 'hide base mesh' modifier if present",
     "label": "Remove delete groups",
     "default": true
 }

--- a/src/mpfb/ui/sculpt/properties/setup_multires.json
+++ b/src/mpfb/ui/sculpt/properties/setup_multires.json
@@ -1,7 +1,7 @@
 {
     "type": "boolean",
     "name": "setup_multires",
-    "description": "Create a multires modifier. This will also remove any subdivision modifier, if present.",
+    "description": "Create a multires modifier. This will also remove any subdivision modifier, if present",
     "label": "Setup multires",
     "default": true
 }


### PR DESCRIPTION
This PR largely concerns janitorial work with strings to conform to blender style recommendations. Most users will see no difference, but it will make the console output less cluttered when using a debug build of blender.

@angavrilov : Can you skim through this and see if you think it solves #44? The only place where the changes might cause a functional difference is in the model sub panels, where the property names have been filtered to remove illegal characters.