### PR TITLE
Fix TypeError, enum "Non-Color" not found in ('Linear', 'sRGB')

### DIFF
--- a/src/mpfb/services/nodeservice.py
+++ b/src/mpfb/services/nodeservice.py
@@ -252,7 +252,7 @@ class NodeService:
             else:
                 _LOG.error("File does not exist:", node_info["filename"])
                 return
-        if "colorspace" in node_info:
+        if "colorspace" in node_info and node_info["colorspace"] != "Non-Color":
             image.colorspace_settings.name = node_info["colorspace"]
         else:
             image.colorspace_settings.name = "sRGB"


### PR DESCRIPTION
# Description

On Blender 3.0.1+dfsg-7 on Ubuntu 22.04, I received the following error while trying to apply the clothing "Female casual suit01".  The full error was:

> Traceback (most recent call last):
>   File "/home/cory/.config/blender/3.0/scripts/addons/mpfb/ui/assetlibrary/operators/loadlibraryclothes.py", line 76, in execute
>     HumanService.add_mhclo_asset(self.filepath, basemesh, asset_type=self.object_type, subdiv_levels=subdiv_levels, material_type=self.material_type)
>   File "/home/cory/.config/blender/3.0/scripts/addons/mpfb/services/humanservice.py", line 323, in add_mhclo_asset
>     makeskin_material.apply_node_tree(blender_material)
>   File "/home/cory/.config/blender/3.0/scripts/addons/mpfb/entities/material/makeskinmaterial.py", line 101, in apply_node_tree
>     NodeService.apply_node_tree_from_dict(blender_material.node_tree, node_tree_dict, True)
>   File "/home/cory/.config/blender/3.0/scripts/addons/mpfb/services/nodeservice.py", line 415, in apply_node_tree_from_dict
>     new_node = NodeService.create_node_from_dict(target_node_tree, node_info)
>   File "/home/cory/.config/blender/3.0/scripts/addons/mpfb/services/nodeservice.py", line 579, in create_node_from_dict
>     NodeService.update_node_with_settings_from_dict(new_node, node_info)
>   File "/home/cory/.config/blender/3.0/scripts/addons/mpfb/services/nodeservice.py", line 280, in update_node_with_settings_from_dict
>     NodeService.update_tex_image_with_settings_from_dict(node, node_info)
>   File "/home/cory/.config/blender/3.0/scripts/addons/mpfb/services/nodeservice.py", line 256, in update_tex_image_with_settings_from_dict
>     image.colorspace_settings.name = node_info["colorspace"]
> TypeError: bpy_struct: item.attr = val: enum "Non-Color" not found in ('Linear', 'sRGB')

This corrected the problem for me.  I'm not familiar enough with Blender or MPFB2 to say whether this is really the correct fix or not, but it seems reasonable.
