### PR TITLE
Support bone collections in Blender 4.0

### DIFF
--- a/src/mpfb/data/rigs/rigify/rig.human.json
+++ b/src/mpfb/data/rigs/rigify/rig.human.json
@@ -1,6 +1,9 @@
 {
     "bones": {
         "DEF-elbow-helper.L": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "name": "Armature@DEF-upper_arm.L.001@DEF",
@@ -85,40 +88,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "",
             "rigify": {
                 "rigify_parameters": {
@@ -141,6 +110,9 @@
             "use_local_location": true
         },
         "DEF-elbow-helper.R": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "name": "Armature@DEF-upper_arm.R.001@DEF",
@@ -225,40 +197,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "",
             "rigify": {
                 "rigify_parameters": {
@@ -281,6 +219,9 @@
             "use_local_location": true
         },
         "DEF-knee-helper.L": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "name": "Armature@DEF-thigh.L.001@DEF",
@@ -365,40 +306,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "",
             "rigify": {
                 "rigify_parameters": {
@@ -422,6 +329,9 @@
             "use_local_location": true
         },
         "DEF-knee-helper.R": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "name": "Armature@DEF-thigh.R.001@DEF",
@@ -506,40 +416,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "",
             "rigify": {
                 "rigify_parameters": {
@@ -563,6 +439,9 @@
             "use_local_location": true
         },
         "DEF-pelvis-helper.L": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "head_tail": 0.0,
@@ -698,40 +577,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "spine",
             "rigify": {
                 "rigify_parameters": {
@@ -768,6 +613,9 @@
             "use_local_location": true
         },
         "DEF-pelvis-helper.R": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "head_tail": 0.0,
@@ -903,40 +751,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "spine",
             "rigify": {
                 "rigify_parameters": {
@@ -973,6 +787,9 @@
             "use_local_location": true
         },
         "DEF-pelvis-helper.front.L": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "from_max_x": 0.0,
@@ -1150,40 +967,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "DEF-pelvis-helper.L",
             "rigify": {
                 "rigify_parameters": {
@@ -1220,6 +1003,9 @@
             "use_local_location": true
         },
         "DEF-pelvis-helper.front.R": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "from_max_x": 0.0,
@@ -1397,40 +1183,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "DEF-pelvis-helper.R",
             "rigify": {
                 "rigify_parameters": {
@@ -1467,6 +1219,9 @@
             "use_local_location": true
         },
         "DEF-shoulder-helper.L": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "head_tail": 0.0,
@@ -1602,40 +1357,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "shoulder.L",
             "rigify": {
                 "rigify_parameters": {
@@ -1672,6 +1393,9 @@
             "use_local_location": true
         },
         "DEF-shoulder-helper.R": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "head_tail": 0.0,
@@ -1807,40 +1531,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "shoulder.R",
             "rigify": {
                 "rigify_parameters": {
@@ -1877,6 +1567,9 @@
             "use_local_location": true
         },
         "MCH-breast-parent": {
+            "collections": [
+                "MCH"
+            ],
             "constraints": [
                 {
                     "name": "Armature@DEF",
@@ -1906,40 +1599,6 @@
                 "vertex_index": 1892
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false
-            ],
             "parent": "",
             "rigify": {
                 "rigify_parameters": {
@@ -1967,6 +1626,9 @@
             "use_local_location": true
         },
         "breast.L": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "default_position": [
                     0.07857,
@@ -1980,40 +1642,6 @@
                 ]
             },
             "inherit_scale": "AVERAGE",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "MCH-breast-parent",
             "rigify": {
                 "rigify_type": "basic.super_copy"
@@ -2034,6 +1662,9 @@
             "use_local_location": true
         },
         "breast.R": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "default_position": [
                     -0.07857,
@@ -2047,40 +1678,6 @@
                 ]
             },
             "inherit_scale": "AVERAGE",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "MCH-breast-parent",
             "rigify": {
                 "rigify_type": "basic.super_copy"
@@ -2101,6 +1698,9 @@
             "use_local_location": true
         },
         "brow.B.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.05155,
@@ -2111,40 +1711,6 @@
                 "vertex_index": 6964
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -2173,6 +1739,9 @@
             "use_local_location": true
         },
         "brow.B.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.04675,
@@ -2183,40 +1752,6 @@
                 "vertex_index": 6938
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.B.L",
             "rigify": {},
             "roll": 0.0,
@@ -2235,6 +1770,9 @@
             "use_local_location": true
         },
         "brow.B.L.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.03878,
@@ -2245,40 +1783,6 @@
                 "vertex_index": 6948
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.B.L.001",
             "rigify": {},
             "roll": 0.0,
@@ -2297,6 +1801,9 @@
             "use_local_location": true
         },
         "brow.B.L.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.02162,
@@ -2307,40 +1814,6 @@
                 "vertex_index": 6950
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.B.L.002",
             "rigify": {},
             "roll": 0.0,
@@ -2359,6 +1832,9 @@
             "use_local_location": true
         },
         "brow.B.L.004": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.01124,
@@ -2369,40 +1845,6 @@
                 "vertex_index": 6897
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -2434,6 +1876,9 @@
             "use_local_location": true
         },
         "brow.B.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.05155,
@@ -2444,40 +1889,6 @@
                 "vertex_index": 188
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -2506,6 +1917,9 @@
             "use_local_location": true
         },
         "brow.B.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.04675,
@@ -2516,40 +1930,6 @@
                 "vertex_index": 160
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.B.R",
             "rigify": {},
             "roll": 0.0,
@@ -2568,6 +1948,9 @@
             "use_local_location": true
         },
         "brow.B.R.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.03878,
@@ -2578,40 +1961,6 @@
                 "vertex_index": 172
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.B.R.001",
             "rigify": {},
             "roll": 0.0,
@@ -2630,6 +1979,9 @@
             "use_local_location": true
         },
         "brow.B.R.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.02162,
@@ -2640,40 +1992,6 @@
                 "vertex_index": 174
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.B.R.002",
             "rigify": {},
             "roll": 0.0,
@@ -2692,6 +2010,9 @@
             "use_local_location": true
         },
         "brow.B.R.004": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.01124,
@@ -2702,40 +2023,6 @@
                 "vertex_index": 113
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -2767,6 +2054,9 @@
             "use_local_location": true
         },
         "brow.T.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.05856,
@@ -2777,40 +2067,6 @@
                 "vertex_index": 7032
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -2838,6 +2094,9 @@
             "use_local_location": true
         },
         "brow.T.L.001": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     0.05421,
@@ -2848,40 +2107,6 @@
                 "vertex_index": 7023
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -2909,6 +2134,9 @@
             "use_local_location": true
         },
         "brow.T.L.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.03984,
@@ -2919,40 +2147,6 @@
                 "vertex_index": 6981
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.T.L.001",
             "rigify": {},
             "roll": 0.0,
@@ -2971,6 +2165,9 @@
             "use_local_location": true
         },
         "brow.T.L.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.01521,
@@ -2981,40 +2178,6 @@
                 "vertex_index": 6983
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3042,6 +2205,9 @@
             "use_local_location": true
         },
         "brow.T.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.05856,
@@ -3052,40 +2218,6 @@
                 "vertex_index": 263
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3113,6 +2245,9 @@
             "use_local_location": true
         },
         "brow.T.R.001": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     -0.05421,
@@ -3123,40 +2258,6 @@
                 "vertex_index": 254
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3184,6 +2285,9 @@
             "use_local_location": true
         },
         "brow.T.R.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.03984,
@@ -3194,40 +2298,6 @@
                 "vertex_index": 206
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.T.R.001",
             "rigify": {},
             "roll": 0.0,
@@ -3246,6 +2316,9 @@
             "use_local_location": true
         },
         "brow.T.R.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.01521,
@@ -3256,40 +2329,6 @@
                 "vertex_index": 208
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3317,6 +2356,9 @@
             "use_local_location": true
         },
         "brow_glue.B.L.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.03878,
@@ -3327,40 +2369,6 @@
                 "vertex_index": 6948
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3387,6 +2395,9 @@
             "use_local_location": true
         },
         "brow_glue.B.R.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.03878,
@@ -3397,40 +2408,6 @@
                 "vertex_index": 172
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3457,6 +2434,9 @@
             "use_local_location": true
         },
         "cheek.B.L": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     0.02282,
@@ -3470,40 +2450,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3530,6 +2476,9 @@
             "use_local_location": true
         },
         "cheek.B.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.05094,
@@ -3540,40 +2489,6 @@
                 "vertex_index": 11767
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "cheek.B.L",
             "rigify": {},
             "roll": -3.91226,
@@ -3591,6 +2506,9 @@
             "use_local_location": true
         },
         "cheek.B.R": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     -0.02282,
@@ -3604,40 +2522,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3664,6 +2548,9 @@
             "use_local_location": true
         },
         "cheek.B.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.05094,
@@ -3674,40 +2561,6 @@
                 "vertex_index": 5153
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "cheek.B.R",
             "rigify": {},
             "roll": 3.91226,
@@ -3725,6 +2578,9 @@
             "use_local_location": true
         },
         "cheek.T.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.05856,
@@ -3735,40 +2591,6 @@
                 "vertex_index": 7032
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3792,6 +2614,9 @@
             "use_local_location": true
         },
         "cheek.T.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.04235,
@@ -3802,40 +2627,6 @@
                 "vertex_index": 11748
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "cheek.T.L",
             "rigify": {},
             "roll": 0.0,
@@ -3854,6 +2645,9 @@
             "use_local_location": true
         },
         "cheek.T.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.05856,
@@ -3864,40 +2658,6 @@
                 "vertex_index": 263
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3921,6 +2681,9 @@
             "use_local_location": true
         },
         "cheek.T.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.04235,
@@ -3931,40 +2694,6 @@
                 "vertex_index": 5133
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "cheek.T.R",
             "rigify": {},
             "roll": 0.0,
@@ -3983,6 +2712,9 @@
             "use_local_location": true
         },
         "cheek_glue.T.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.04235,
@@ -3993,40 +2725,6 @@
                 "vertex_index": 11748
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -4053,6 +2751,9 @@
             "use_local_location": true
         },
         "cheek_glue.T.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.04235,
@@ -4063,40 +2764,6 @@
                 "vertex_index": 5133
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -4123,6 +2790,9 @@
             "use_local_location": true
         },
         "chin": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -4133,40 +2803,6 @@
                 "vertex_index": 5225
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -4193,6 +2829,9 @@
             "use_local_location": true
         },
         "chin.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -4203,40 +2842,6 @@
                 "vertex_index": 5162
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "chin",
             "rigify": {},
             "roll": 0.0,
@@ -4254,6 +2859,9 @@
             "use_local_location": true
         },
         "chin.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.02626,
@@ -4264,40 +2872,6 @@
                 "vertex_index": 11833
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw.L.001",
             "rigify": {},
             "roll": 2.19646,
@@ -4318,6 +2892,9 @@
             "use_local_location": true
         },
         "chin.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.02626,
@@ -4328,40 +2905,6 @@
                 "vertex_index": 5223
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw.R.001",
             "rigify": {},
             "roll": -2.19646,
@@ -4382,6 +2925,9 @@
             "use_local_location": true
         },
         "chin_end_glue.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -4392,40 +2938,6 @@
                 "vertex_index": 491
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -4455,6 +2967,9 @@
             "use_local_location": true
         },
         "ear.L": {
+            "collections": [
+                "Face"
+            ],
             "head": {
                 "default_position": [
                     0.06924,
@@ -4465,40 +2980,6 @@
                 "vertex_index": 12020
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -4521,6 +3002,9 @@
             "use_local_location": true
         },
         "ear.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.07043,
@@ -4531,40 +3015,6 @@
                 "vertex_index": 12165
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "ear.L",
             "rigify": {
                 "rigify_parameters": {
@@ -4594,6 +3044,9 @@
             "use_local_location": true
         },
         "ear.L.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0788,
@@ -4607,40 +3060,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "ear.L",
             "rigify": {
                 "rigify_parameters": {
@@ -4670,6 +3089,9 @@
             "use_local_location": true
         },
         "ear.L.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.07883,
@@ -4683,40 +3105,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "ear.L.002",
             "rigify": {},
             "roll": 0.74592,
@@ -4737,6 +3125,9 @@
             "use_local_location": true
         },
         "ear.L.004": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.07314,
@@ -4750,40 +3141,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "ear.L",
             "rigify": {
                 "rigify_parameters": {
@@ -4810,6 +3167,9 @@
             "use_local_location": true
         },
         "ear.R": {
+            "collections": [
+                "Face"
+            ],
             "head": {
                 "default_position": [
                     -0.06924,
@@ -4820,40 +3180,6 @@
                 "vertex_index": 5421
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -4876,6 +3202,9 @@
             "use_local_location": true
         },
         "ear.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.07043,
@@ -4886,40 +3215,6 @@
                 "vertex_index": 5568
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "ear.R",
             "rigify": {
                 "rigify_parameters": {
@@ -4949,6 +3244,9 @@
             "use_local_location": true
         },
         "ear.R.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.0788,
@@ -4962,40 +3260,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "ear.R",
             "rigify": {
                 "rigify_parameters": {
@@ -5025,6 +3289,9 @@
             "use_local_location": true
         },
         "ear.R.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.07883,
@@ -5038,40 +3305,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "ear.R.002",
             "rigify": {},
             "roll": -0.74592,
@@ -5092,6 +3325,9 @@
             "use_local_location": true
         },
         "ear.R.004": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.07314,
@@ -5105,40 +3341,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "ear.R",
             "rigify": {
                 "rigify_parameters": {
@@ -5165,6 +3367,9 @@
             "use_local_location": true
         },
         "eye.L": {
+            "collections": [
+                "Face"
+            ],
             "head": {
                 "cube_name": "joint-l-eye",
                 "default_position": [
@@ -5175,40 +3380,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_type": "face.skin_eye"
@@ -5232,6 +3403,9 @@
             "use_local_location": true
         },
         "eye.R": {
+            "collections": [
+                "Face"
+            ],
             "head": {
                 "cube_name": "joint-r-eye",
                 "default_position": [
@@ -5242,40 +3416,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_type": "face.skin_eye"
@@ -5299,6 +3439,9 @@
             "use_local_location": true
         },
         "f_index.01.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-2-1",
                 "default_position": [
@@ -5309,77 +3452,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.01.L",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -5400,6 +3478,9 @@
             "use_local_location": true
         },
         "f_index.01.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-2-1",
                 "default_position": [
@@ -5410,77 +3491,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.01.R",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -5501,6 +3517,9 @@
             "use_local_location": true
         },
         "f_index.02.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-2-2",
                 "default_position": [
@@ -5511,40 +3530,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_index.01.L",
             "rigify": {},
             "roll": -0.81155,
@@ -5563,6 +3548,9 @@
             "use_local_location": true
         },
         "f_index.02.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-2-2",
                 "default_position": [
@@ -5573,40 +3561,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_index.01.R",
             "rigify": {},
             "roll": 0.81155,
@@ -5625,6 +3579,9 @@
             "use_local_location": true
         },
         "f_index.03.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-2-3",
                 "default_position": [
@@ -5635,40 +3592,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_index.02.L",
             "rigify": {},
             "roll": -0.56598,
@@ -5687,6 +3610,9 @@
             "use_local_location": true
         },
         "f_index.03.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-2-3",
                 "default_position": [
@@ -5697,40 +3623,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_index.02.R",
             "rigify": {},
             "roll": 0.56598,
@@ -5749,6 +3641,9 @@
             "use_local_location": true
         },
         "f_middle.01.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-3-1",
                 "default_position": [
@@ -5759,77 +3654,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.02.L",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -5850,6 +3680,9 @@
             "use_local_location": true
         },
         "f_middle.01.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-3-1",
                 "default_position": [
@@ -5860,77 +3693,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.02.R",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -5951,6 +3719,9 @@
             "use_local_location": true
         },
         "f_middle.02.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-3-2",
                 "default_position": [
@@ -5961,40 +3732,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_middle.01.L",
             "rigify": {},
             "roll": -1.27877,
@@ -6013,6 +3750,9 @@
             "use_local_location": true
         },
         "f_middle.02.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-3-2",
                 "default_position": [
@@ -6023,40 +3763,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_middle.01.R",
             "rigify": {},
             "roll": 1.27877,
@@ -6075,6 +3781,9 @@
             "use_local_location": true
         },
         "f_middle.03.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-3-3",
                 "default_position": [
@@ -6085,40 +3794,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_middle.02.L",
             "rigify": {},
             "roll": -1.05372,
@@ -6137,6 +3812,9 @@
             "use_local_location": true
         },
         "f_middle.03.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-3-3",
                 "default_position": [
@@ -6147,40 +3825,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_middle.02.R",
             "rigify": {},
             "roll": 1.05372,
@@ -6199,6 +3843,9 @@
             "use_local_location": true
         },
         "f_pinky.01.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-5-1",
                 "default_position": [
@@ -6209,77 +3856,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.04.L",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -6300,6 +3882,9 @@
             "use_local_location": true
         },
         "f_pinky.01.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-5-1",
                 "default_position": [
@@ -6310,77 +3895,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.04.R",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -6401,6 +3921,9 @@
             "use_local_location": true
         },
         "f_pinky.02.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-5-2",
                 "default_position": [
@@ -6411,40 +3934,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_pinky.01.L",
             "rigify": {},
             "roll": -1.37208,
@@ -6463,6 +3952,9 @@
             "use_local_location": true
         },
         "f_pinky.02.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-5-2",
                 "default_position": [
@@ -6473,40 +3965,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_pinky.01.R",
             "rigify": {},
             "roll": 1.37208,
@@ -6525,6 +3983,9 @@
             "use_local_location": true
         },
         "f_pinky.03.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-5-3",
                 "default_position": [
@@ -6535,40 +3996,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_pinky.02.L",
             "rigify": {},
             "roll": -1.39831,
@@ -6587,6 +4014,9 @@
             "use_local_location": true
         },
         "f_pinky.03.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-5-3",
                 "default_position": [
@@ -6597,40 +4027,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_pinky.02.R",
             "rigify": {},
             "roll": 1.39831,
@@ -6649,6 +4045,9 @@
             "use_local_location": true
         },
         "f_ring.01.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-4-1",
                 "default_position": [
@@ -6659,77 +4058,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.03.L",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -6750,6 +4084,9 @@
             "use_local_location": true
         },
         "f_ring.01.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-4-1",
                 "default_position": [
@@ -6760,77 +4097,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.03.R",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -6851,6 +4123,9 @@
             "use_local_location": true
         },
         "f_ring.02.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-4-2",
                 "default_position": [
@@ -6861,40 +4136,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_ring.01.L",
             "rigify": {},
             "roll": -1.44243,
@@ -6913,6 +4154,9 @@
             "use_local_location": true
         },
         "f_ring.02.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-4-2",
                 "default_position": [
@@ -6923,40 +4167,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_ring.01.R",
             "rigify": {},
             "roll": 1.44243,
@@ -6975,6 +4185,9 @@
             "use_local_location": true
         },
         "f_ring.03.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-4-3",
                 "default_position": [
@@ -6985,40 +4198,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_ring.02.L",
             "rigify": {},
             "roll": -1.28095,
@@ -7037,6 +4216,9 @@
             "use_local_location": true
         },
         "f_ring.03.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-4-3",
                 "default_position": [
@@ -7047,40 +4229,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_ring.02.R",
             "rigify": {},
             "roll": 1.28095,
@@ -7099,6 +4247,11 @@
             "use_local_location": true
         },
         "face": {
+            "collections": [
+                "Face",
+                "Face (Primary)",
+                "Face (Secondary)"
+            ],
             "head": {
                 "cube_name": "joint-head",
                 "default_position": [
@@ -7109,76 +4262,11 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                true,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine.006",
             "rigify": {
                 "rigify_parameters": {
-                    "secondary_layers": [
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "secondary_coll_refs": [
+                        "Face (Secondary)"
                     ]
                 }
             },
@@ -7202,6 +4290,9 @@
             "use_local_location": true
         },
         "foot.L": {
+            "collections": [
+                "Leg.L (IK)"
+            ],
             "head": {
                 "cube_name": "joint-l-ankle",
                 "default_position": [
@@ -7212,40 +4303,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "shin.L",
             "rigify": {},
             "roll": 0.0,
@@ -7265,6 +4322,9 @@
             "use_local_location": true
         },
         "foot.R": {
+            "collections": [
+                "Leg.R (IK)"
+            ],
             "head": {
                 "cube_name": "joint-r-ankle",
                 "default_position": [
@@ -7275,40 +4335,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "shin.R",
             "rigify": {},
             "roll": 0.0,
@@ -7328,6 +4354,9 @@
             "use_local_location": true
         },
         "forearm.L": {
+            "collections": [
+                "Arm.L (IK)"
+            ],
             "head": {
                 "cube_name": "joint-l-elbow",
                 "default_position": [
@@ -7338,40 +4367,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "upper_arm.L",
             "rigify": {},
             "roll": 2.1535,
@@ -7390,6 +4385,9 @@
             "use_local_location": true
         },
         "forearm.R": {
+            "collections": [
+                "Arm.R (IK)"
+            ],
             "head": {
                 "cube_name": "joint-r-elbow",
                 "default_position": [
@@ -7400,40 +4398,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "upper_arm.R",
             "rigify": {},
             "roll": -2.1535,
@@ -7452,6 +4416,9 @@
             "use_local_location": true
         },
         "forehead.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.00814,
@@ -7462,40 +4429,6 @@
                 "vertex_index": 7015
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -7518,6 +4451,9 @@
             "use_local_location": true
         },
         "forehead.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0282,
@@ -7528,40 +4464,6 @@
                 "vertex_index": 7011
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -7584,6 +4486,9 @@
             "use_local_location": true
         },
         "forehead.L.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.04982,
@@ -7594,40 +4499,6 @@
                 "vertex_index": 7018
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -7650,6 +4521,9 @@
             "use_local_location": true
         },
         "forehead.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.00814,
@@ -7660,40 +4534,6 @@
                 "vertex_index": 245
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -7716,6 +4556,9 @@
             "use_local_location": true
         },
         "forehead.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.0282,
@@ -7726,40 +4569,6 @@
                 "vertex_index": 240
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -7782,6 +4591,9 @@
             "use_local_location": true
         },
         "forehead.R.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.04982,
@@ -7792,40 +4604,6 @@
                 "vertex_index": 248
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -7848,6 +4626,9 @@
             "use_local_location": true
         },
         "hand.L": {
+            "collections": [
+                "Arm.L (IK)"
+            ],
             "head": {
                 "cube_name": "joint-l-hand",
                 "default_position": [
@@ -7858,40 +4639,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "forearm.L",
             "rigify": {},
             "roll": 2.2103,
@@ -7910,6 +4657,9 @@
             "use_local_location": true
         },
         "hand.R": {
+            "collections": [
+                "Arm.R (IK)"
+            ],
             "head": {
                 "cube_name": "joint-r-hand",
                 "default_position": [
@@ -7920,40 +4670,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "forearm.R",
             "rigify": {},
             "roll": -2.2103,
@@ -7972,6 +4688,9 @@
             "use_local_location": true
         },
         "heel.02.L": {
+            "collections": [
+                "Leg.L (IK)"
+            ],
             "head": {
                 "default_position": [
                     0.14959,
@@ -7986,40 +4705,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "foot.L",
             "rigify": {},
             "roll": 0.0,
@@ -8041,6 +4726,9 @@
             "use_local_location": true
         },
         "heel.02.R": {
+            "collections": [
+                "Leg.R (IK)"
+            ],
             "head": {
                 "default_position": [
                     -0.14959,
@@ -8055,40 +4743,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "foot.R",
             "rigify": {},
             "roll": 0.0,
@@ -8110,6 +4764,9 @@
             "use_local_location": true
         },
         "jaw": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -8120,40 +4777,6 @@
                 "vertex_index": 783
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -8180,6 +4803,9 @@
             "use_local_location": true
         },
         "jaw.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.06545,
@@ -8190,40 +4816,6 @@
                 "vertex_index": 11712
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -8250,6 +4842,9 @@
             "use_local_location": true
         },
         "jaw.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.05626,
@@ -8260,40 +4855,6 @@
                 "vertex_index": 7597
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw.L",
             "rigify": {},
             "roll": -1.72746,
@@ -8311,6 +4872,9 @@
             "use_local_location": true
         },
         "jaw.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.06545,
@@ -8321,40 +4885,6 @@
                 "vertex_index": 5097
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -8381,6 +4911,9 @@
             "use_local_location": true
         },
         "jaw.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.05626,
@@ -8391,40 +4924,6 @@
                 "vertex_index": 895
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw.R",
             "rigify": {},
             "roll": 1.72746,
@@ -8442,6 +4941,9 @@
             "use_local_location": true
         },
         "jaw_master": {
+            "collections": [
+                "Face"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -8455,40 +4957,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -8511,6 +4979,9 @@
             "use_local_location": true
         },
         "lid.B.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.04325,
@@ -8521,78 +4992,13 @@
                 "vertex_index": 6806
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "eye.L",
             "rigify": {
                 "rigify_parameters": {
                     "skin_chain_pivot_pos": 2,
                     "skin_control_orientation_bone": "face",
-                    "skin_secondary_layers": [
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "skin_secondary_coll_refs": [
+                        "Face (Primary)"
                     ],
                     "skin_secondary_layers_extra": true
                 },
@@ -8614,6 +5020,9 @@
             "use_local_location": true
         },
         "lid.B.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.03956,
@@ -8624,40 +5033,6 @@
                 "vertex_index": 6818
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.B.L",
             "rigify": {},
             "roll": 0.0,
@@ -8676,6 +5051,9 @@
             "use_local_location": true
         },
         "lid.B.L.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.02949,
@@ -8686,40 +5064,6 @@
                 "vertex_index": 6827
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.B.L.001",
             "rigify": {},
             "roll": 0.0,
@@ -8738,6 +5082,9 @@
             "use_local_location": true
         },
         "lid.B.L.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0222,
@@ -8748,40 +5095,6 @@
                 "vertex_index": 6833
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.B.L.002",
             "rigify": {},
             "roll": 0.0,
@@ -8800,6 +5113,9 @@
             "use_local_location": true
         },
         "lid.B.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.04325,
@@ -8810,78 +5126,13 @@
                 "vertex_index": 22
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "eye.R",
             "rigify": {
                 "rigify_parameters": {
                     "skin_chain_pivot_pos": 2,
                     "skin_control_orientation_bone": "face",
-                    "skin_secondary_layers": [
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "skin_secondary_coll_refs": [
+                        "Face (Primary)"
                     ],
                     "skin_secondary_layers_extra": true
                 },
@@ -8903,6 +5154,9 @@
             "use_local_location": true
         },
         "lid.B.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.03956,
@@ -8913,40 +5167,6 @@
                 "vertex_index": 34
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.B.R",
             "rigify": {},
             "roll": 0.0,
@@ -8965,6 +5185,9 @@
             "use_local_location": true
         },
         "lid.B.R.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.02949,
@@ -8975,40 +5198,6 @@
                 "vertex_index": 43
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.B.R.001",
             "rigify": {},
             "roll": 0.0,
@@ -9027,6 +5216,9 @@
             "use_local_location": true
         },
         "lid.B.R.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.0222,
@@ -9037,40 +5229,6 @@
                 "vertex_index": 49
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.B.R.002",
             "rigify": {},
             "roll": 0.0,
@@ -9089,6 +5247,9 @@
             "use_local_location": true
         },
         "lid.T.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.01556,
@@ -9099,40 +5260,6 @@
                 "vertex_index": 6851
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "eye.L",
             "rigify": {
                 "rigify_parameters": {
@@ -9143,39 +5270,8 @@
                     ],
                     "skin_chain_pivot_pos": 2,
                     "skin_control_orientation_bone": "face",
-                    "skin_secondary_layers": [
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "skin_secondary_coll_refs": [
+                        "Face (Primary)"
                     ],
                     "skin_secondary_layers_extra": true
                 },
@@ -9197,6 +5293,9 @@
             "use_local_location": true
         },
         "lid.T.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.02179,
@@ -9207,40 +5306,6 @@
                 "vertex_index": 6842
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.T.L",
             "rigify": {},
             "roll": 0.0,
@@ -9259,6 +5324,9 @@
             "use_local_location": true
         },
         "lid.T.L.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.02914,
@@ -9269,40 +5337,6 @@
                 "vertex_index": 6787
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.T.L.001",
             "rigify": {},
             "roll": 0.0,
@@ -9321,6 +5355,9 @@
             "use_local_location": true
         },
         "lid.T.L.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.03916,
@@ -9331,40 +5368,6 @@
                 "vertex_index": 6794
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.T.L.002",
             "rigify": {},
             "roll": 0.0,
@@ -9383,6 +5386,9 @@
             "use_local_location": true
         },
         "lid.T.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.01556,
@@ -9393,40 +5399,6 @@
                 "vertex_index": 67
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "eye.R",
             "rigify": {
                 "rigify_parameters": {
@@ -9437,39 +5409,8 @@
                     ],
                     "skin_chain_pivot_pos": 2,
                     "skin_control_orientation_bone": "face",
-                    "skin_secondary_layers": [
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "skin_secondary_coll_refs": [
+                        "Face (Primary)"
                     ],
                     "skin_secondary_layers_extra": true
                 },
@@ -9491,6 +5432,9 @@
             "use_local_location": true
         },
         "lid.T.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.02179,
@@ -9501,40 +5445,6 @@
                 "vertex_index": 58
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.T.R",
             "rigify": {},
             "roll": 0.0,
@@ -9553,6 +5463,9 @@
             "use_local_location": true
         },
         "lid.T.R.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.02914,
@@ -9563,40 +5476,6 @@
                 "vertex_index": 3
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.T.R.001",
             "rigify": {},
             "roll": 0.0,
@@ -9615,6 +5494,9 @@
             "use_local_location": true
         },
         "lid.T.R.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.03916,
@@ -9625,40 +5507,6 @@
                 "vertex_index": 10
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.T.R.002",
             "rigify": {},
             "roll": 0.0,
@@ -9677,6 +5525,9 @@
             "use_local_location": true
         },
         "lid_glue.B.L.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.02949,
@@ -9687,40 +5538,6 @@
                 "vertex_index": 6827
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -9747,6 +5564,9 @@
             "use_local_location": true
         },
         "lid_glue.B.R.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.02949,
@@ -9757,40 +5577,6 @@
                 "vertex_index": 43
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -9817,6 +5603,9 @@
             "use_local_location": true
         },
         "lip.B.L": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -9830,40 +5619,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -9911,6 +5666,9 @@
             "use_local_location": true
         },
         "lip.B.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.01172,
@@ -9924,40 +5682,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lip.B.L",
             "rigify": {},
             "roll": 0.0,
@@ -9979,6 +5703,9 @@
             "use_local_location": true
         },
         "lip.B.R": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -9992,40 +5719,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -10073,6 +5766,9 @@
             "use_local_location": true
         },
         "lip.B.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.01172,
@@ -10086,40 +5782,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lip.B.R",
             "rigify": {},
             "roll": 0.0,
@@ -10141,6 +5803,9 @@
             "use_local_location": true
         },
         "lip.T.L": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -10154,40 +5819,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -10235,6 +5866,9 @@
             "use_local_location": true
         },
         "lip.T.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.01219,
@@ -10248,40 +5882,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lip.T.L",
             "rigify": {},
             "roll": 0.0,
@@ -10303,6 +5903,9 @@
             "use_local_location": true
         },
         "lip.T.R": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -10316,40 +5919,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -10397,6 +5966,9 @@
             "use_local_location": true
         },
         "lip.T.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.01219,
@@ -10410,40 +5982,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lip.T.R",
             "rigify": {},
             "roll": 0.0,
@@ -10465,6 +6003,9 @@
             "use_local_location": true
         },
         "nose": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -10475,40 +6016,6 @@
                 "vertex_index": 132
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -10536,6 +6043,9 @@
             "use_local_location": true
         },
         "nose.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -10546,40 +6056,6 @@
                 "vertex_index": 164
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "nose",
             "rigify": {},
             "roll": 0.0,
@@ -10597,6 +6073,9 @@
             "use_local_location": true
         },
         "nose.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -10607,40 +6086,6 @@
                 "vertex_index": 297
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "nose_master",
             "rigify": {
                 "rigify_parameters": {
@@ -10668,6 +6113,9 @@
             "use_local_location": true
         },
         "nose.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -10678,40 +6126,6 @@
                 "vertex_index": 312
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "nose.002",
             "rigify": {},
             "roll": 0.0,
@@ -10729,6 +6143,9 @@
             "use_local_location": true
         },
         "nose.004": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -10739,40 +6156,6 @@
                 "vertex_index": 343
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -10799,6 +6182,9 @@
             "use_local_location": true
         },
         "nose.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.01212,
@@ -10809,40 +6195,6 @@
                 "vertex_index": 11715
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.B.L.004",
             "rigify": {},
             "roll": -1.81298,
@@ -10860,6 +6212,9 @@
             "use_local_location": true
         },
         "nose.L.001": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     0.0171,
@@ -10870,40 +6225,6 @@
                 "vertex_index": 7099
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "nose_master",
             "rigify": {
                 "rigify_parameters": {
@@ -10927,6 +6248,9 @@
             "use_local_location": true
         },
         "nose.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.01212,
@@ -10937,40 +6261,6 @@
                 "vertex_index": 5100
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.B.R.004",
             "rigify": {},
             "roll": 1.81298,
@@ -10988,6 +6278,9 @@
             "use_local_location": true
         },
         "nose.R.001": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     -0.0171,
@@ -10998,40 +6291,6 @@
                 "vertex_index": 337
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "nose_master",
             "rigify": {
                 "rigify_parameters": {
@@ -11055,6 +6314,9 @@
             "use_local_location": true
         },
         "nose_end_glue.004": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -11065,40 +6327,6 @@
                 "vertex_index": 5342
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -11128,6 +6356,9 @@
             "use_local_location": true
         },
         "nose_glue.004": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -11138,40 +6369,6 @@
                 "vertex_index": 343
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -11201,6 +6398,9 @@
             "use_local_location": true
         },
         "nose_glue.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0171,
@@ -11211,40 +6411,6 @@
                 "vertex_index": 7099
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -11274,6 +6440,9 @@
             "use_local_location": true
         },
         "nose_glue.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.0171,
@@ -11284,40 +6453,6 @@
                 "vertex_index": 337
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -11347,6 +6482,9 @@
             "use_local_location": true
         },
         "nose_master": {
+            "collections": [
+                "Face"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -11360,40 +6498,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -11425,6 +6529,9 @@
             "use_local_location": true
         },
         "palm.01.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-1-1",
                 "default_position": [
@@ -11435,40 +6542,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "hand.L",
             "rigify": {
                 "rigify_type": "limbs.super_palm"
@@ -11488,6 +6561,9 @@
             "use_local_location": true
         },
         "palm.01.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-1-1",
                 "default_position": [
@@ -11498,40 +6574,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "hand.R",
             "rigify": {
                 "rigify_type": "limbs.super_palm"
@@ -11551,6 +6593,9 @@
             "use_local_location": true
         },
         "palm.02.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-hand-3",
                 "default_position": [
@@ -11561,40 +6606,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "hand.L",
             "rigify": {},
             "roll": -2.29223,
@@ -11612,6 +6623,9 @@
             "use_local_location": true
         },
         "palm.02.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-hand-3",
                 "default_position": [
@@ -11622,40 +6636,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "hand.R",
             "rigify": {},
             "roll": 2.29223,
@@ -11673,6 +6653,9 @@
             "use_local_location": true
         },
         "palm.03.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "default_position": [
                     0.47306,
@@ -11686,40 +6669,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "hand.L",
             "rigify": {},
             "roll": -2.36717,
@@ -11737,6 +6686,9 @@
             "use_local_location": true
         },
         "palm.03.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "default_position": [
                     -0.47306,
@@ -11750,40 +6702,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "hand.R",
             "rigify": {},
             "roll": 2.36717,
@@ -11801,6 +6719,9 @@
             "use_local_location": true
         },
         "palm.04.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "default_position": [
                     0.477,
@@ -11814,40 +6735,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "hand.L",
             "rigify": {},
             "roll": -2.24642,
@@ -11865,6 +6752,9 @@
             "use_local_location": true
         },
         "palm.04.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "default_position": [
                     -0.477,
@@ -11878,40 +6768,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "hand.R",
             "rigify": {},
             "roll": 2.24642,
@@ -11929,6 +6785,9 @@
             "use_local_location": true
         },
         "pelvis.L": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-pelvis",
                 "default_position": [
@@ -11939,40 +6798,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine",
             "rigify": {
                 "rigify_parameters": {
@@ -11996,6 +6821,9 @@
             "use_local_location": true
         },
         "pelvis.R": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-pelvis",
                 "default_position": [
@@ -12006,40 +6834,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine",
             "rigify": {
                 "rigify_parameters": {
@@ -12063,6 +6857,9 @@
             "use_local_location": true
         },
         "shin.L": {
+            "collections": [
+                "Leg.L (IK)"
+            ],
             "head": {
                 "cube_name": "joint-l-knee",
                 "default_position": [
@@ -12073,40 +6870,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "thigh.L",
             "rigify": {},
             "roll": 0.0,
@@ -12126,6 +6889,9 @@
             "use_local_location": true
         },
         "shin.R": {
+            "collections": [
+                "Leg.R (IK)"
+            ],
             "head": {
                 "cube_name": "joint-r-knee",
                 "default_position": [
@@ -12136,40 +6902,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "thigh.R",
             "rigify": {},
             "roll": 0.0,
@@ -12189,6 +6921,9 @@
             "use_local_location": true
         },
         "shoulder.L": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-l-clavicle",
                 "default_position": [
@@ -12199,40 +6934,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine.004",
             "rigify": {
                 "rigify_parameters": {
@@ -12258,6 +6959,9 @@
             "use_local_location": true
         },
         "shoulder.R": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-r-clavicle",
                 "default_position": [
@@ -12268,40 +6972,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine.004",
             "rigify": {
                 "rigify_parameters": {
@@ -12327,6 +6997,9 @@
             "use_local_location": true
         },
         "spine": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -12337,110 +7010,14 @@
                 "vertex_index": 4374
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "",
             "rigify": {
                 "rigify_parameters": {
-                    "fk_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "fk_coll_refs": [
+                        "Torso (Tweak)"
                     ],
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Torso (Tweak)"
                     ]
                 },
                 "rigify_type": "spines.basic_spine"
@@ -12461,6 +7038,9 @@
             "use_local_location": true
         },
         "spine.001": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-spine-4",
                 "default_position": [
@@ -12471,40 +7051,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine",
             "rigify": {},
             "roll": 0.0,
@@ -12523,6 +7069,9 @@
             "use_local_location": true
         },
         "spine.002": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-spine-3",
                 "default_position": [
@@ -12533,40 +7082,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine.001",
             "rigify": {},
             "roll": 0.0,
@@ -12585,6 +7100,9 @@
             "use_local_location": true
         },
         "spine.003": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-spine-2",
                 "default_position": [
@@ -12595,40 +7113,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine.002",
             "rigify": {},
             "roll": 0.0,
@@ -12647,6 +7131,9 @@
             "use_local_location": true
         },
         "spine.004": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-spine-1",
                 "default_position": [
@@ -12657,40 +7144,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine.003",
             "rigify": {},
             "roll": 0.0,
@@ -12709,6 +7162,9 @@
             "use_local_location": true
         },
         "spine.005": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-neck",
                 "default_position": [
@@ -12719,77 +7175,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine.004",
             "rigify": {
                 "rigify_parameters": {
                     "connect_chain": true,
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Torso (Tweak)"
                     ]
                 },
                 "rigify_type": "spines.super_head"
@@ -12809,6 +7200,9 @@
             "use_local_location": true
         },
         "spine.006": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-head",
                 "default_position": [
@@ -12819,40 +7213,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine.005",
             "rigify": {},
             "roll": 0.0,
@@ -12870,6 +7230,9 @@
             "use_local_location": true
         },
         "teeth.B": {
+            "collections": [
+                "Face"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -12880,40 +7243,6 @@
                 "vertex_index": 15012
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -12939,6 +7268,9 @@
             "use_local_location": true
         },
         "teeth.T": {
+            "collections": [
+                "Face"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -12949,40 +7281,6 @@
                 "vertex_index": 15079
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -13008,6 +7306,9 @@
             "use_local_location": true
         },
         "temple.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.06534,
@@ -13018,40 +7319,6 @@
                 "vertex_index": 12159
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -13075,6 +7342,9 @@
             "use_local_location": true
         },
         "temple.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.06534,
@@ -13085,40 +7355,6 @@
                 "vertex_index": 5562
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -13142,6 +7378,9 @@
             "use_local_location": true
         },
         "thigh.L": {
+            "collections": [
+                "Leg.L (IK)"
+            ],
             "head": {
                 "cube_name": "joint-l-upper-leg",
                 "default_position": [
@@ -13152,115 +7391,19 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine",
             "rigify": {
                 "rigify_parameters": {
                     "auto_align_extremity": true,
                     "extra_ik_toe": true,
-                    "fk_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "fk_coll_refs": [
+                        "Leg.L (FK)"
                     ],
                     "ik_local_location": false,
                     "limb_type": "leg",
                     "rotation_axis": "x",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Leg.L (Tweak)"
                     ]
                 },
                 "rigify_type": "limbs.super_limb"
@@ -13281,6 +7424,9 @@
             "use_local_location": true
         },
         "thigh.R": {
+            "collections": [
+                "Leg.R (IK)"
+            ],
             "head": {
                 "cube_name": "joint-r-upper-leg",
                 "default_position": [
@@ -13291,115 +7437,19 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine",
             "rigify": {
                 "rigify_parameters": {
                     "auto_align_extremity": true,
                     "extra_ik_toe": true,
-                    "fk_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "fk_coll_refs": [
+                        "Leg.R (FK)"
                     ],
                     "ik_local_location": false,
                     "limb_type": "leg",
                     "rotation_axis": "x",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Leg.R (Tweak)"
                     ]
                 },
                 "rigify_type": "limbs.super_limb"
@@ -13420,6 +7470,9 @@
             "use_local_location": true
         },
         "thumb.01.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-1-1",
                 "default_position": [
@@ -13430,77 +7483,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.01.L",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -13521,6 +7509,9 @@
             "use_local_location": true
         },
         "thumb.01.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-1-1",
                 "default_position": [
@@ -13531,77 +7522,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.01.R",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -13622,6 +7548,9 @@
             "use_local_location": true
         },
         "thumb.02.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-1-2",
                 "default_position": [
@@ -13632,40 +7561,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "thumb.01.L",
             "rigify": {},
             "roll": 1.88462,
@@ -13684,6 +7579,9 @@
             "use_local_location": true
         },
         "thumb.02.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-1-2",
                 "default_position": [
@@ -13694,40 +7592,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "thumb.01.R",
             "rigify": {},
             "roll": -1.88462,
@@ -13746,6 +7610,9 @@
             "use_local_location": true
         },
         "thumb.03.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-1-3",
                 "default_position": [
@@ -13756,40 +7623,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "thumb.02.L",
             "rigify": {},
             "roll": 1.15032,
@@ -13808,6 +7641,9 @@
             "use_local_location": true
         },
         "thumb.03.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-1-3",
                 "default_position": [
@@ -13818,40 +7654,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "thumb.02.R",
             "rigify": {},
             "roll": -1.15032,
@@ -13870,6 +7672,9 @@
             "use_local_location": true
         },
         "toe.L": {
+            "collections": [
+                "Leg.L (IK)"
+            ],
             "head": {
                 "cube_name": "joint-l-foot-1",
                 "default_position": [
@@ -13880,40 +7685,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "foot.L",
             "rigify": {},
             "roll": 0.0,
@@ -13933,6 +7704,9 @@
             "use_local_location": true
         },
         "toe.R": {
+            "collections": [
+                "Leg.R (IK)"
+            ],
             "head": {
                 "cube_name": "joint-r-foot-1",
                 "default_position": [
@@ -13943,40 +7717,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "foot.R",
             "rigify": {},
             "roll": 0.0,
@@ -13996,6 +7736,9 @@
             "use_local_location": true
         },
         "tongue": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "cube_name": "joint-tongue-4",
                 "default_position": [
@@ -14006,40 +7749,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_type": "face.basic_tongue"
@@ -14059,6 +7768,9 @@
             "use_local_location": true
         },
         "tongue.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "cube_name": "joint-tongue-3",
                 "default_position": [
@@ -14069,40 +7781,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "tongue",
             "rigify": {},
             "roll": 0.0,
@@ -14120,6 +7798,9 @@
             "use_local_location": true
         },
         "tongue.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "cube_name": "joint-tongue-2",
                 "default_position": [
@@ -14130,40 +7811,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "tongue.001",
             "rigify": {},
             "roll": 0.0,
@@ -14181,6 +7828,9 @@
             "use_local_location": true
         },
         "upper_arm.L": {
+            "collections": [
+                "Arm.L (IK)"
+            ],
             "head": {
                 "cube_name": "joint-l-shoulder",
                 "default_position": [
@@ -14191,111 +7841,15 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "shoulder.L",
             "rigify": {
                 "rigify_parameters": {
-                    "fk_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "fk_coll_refs": [
+                        "Arm.L (FK)"
                     ],
                     "ik_local_location": false,
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Arm.L (Tweak)"
                     ]
                 },
                 "rigify_type": "limbs.super_limb"
@@ -14315,6 +7869,9 @@
             "use_local_location": true
         },
         "upper_arm.R": {
+            "collections": [
+                "Arm.R (IK)"
+            ],
             "head": {
                 "cube_name": "joint-r-shoulder",
                 "default_position": [
@@ -14325,111 +7882,15 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "shoulder.R",
             "rigify": {
                 "rigify_parameters": {
-                    "fk_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "fk_coll_refs": [
+                        "Arm.R (FK)"
                     ],
                     "ik_local_location": false,
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Arm.R (Tweak)"
                     ]
                 },
                 "rigify_type": "limbs.super_limb"
@@ -14449,6 +7910,30 @@
             "use_local_location": true
         }
     },
+    "collections": [
+        "Face",
+        "Face (Primary)",
+        "Face (Secondary)",
+        "Torso",
+        "Torso (Tweak)",
+        "Fingers",
+        "Fingers (Detail)",
+        "Arm.L (IK)",
+        "Arm.L (FK)",
+        "Arm.L (Tweak)",
+        "Arm.R (IK)",
+        "Arm.R (FK)",
+        "Arm.R (Tweak)",
+        "Leg.L (IK)",
+        "Leg.L (FK)",
+        "Leg.L (Tweak)",
+        "Leg.R (IK)",
+        "Leg.R (FK)",
+        "Leg.R (Tweak)",
+        "Root",
+        "DEF",
+        "MCH"
+    ],
     "extra_bones": [
         "DEF-eye_iris.L",
         "DEF-eye_iris.R",
@@ -14465,6 +7950,162 @@
     ],
     "is_subrig": false,
     "rigify_ui": {
+        "collections": {
+            "Arm.L (FK)": {
+                "color_set_id": 5,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 11,
+                "ui_title": "(FK)"
+            },
+            "Arm.L (IK)": {
+                "color_set_id": 2,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 10,
+                "ui_title": ""
+            },
+            "Arm.L (Tweak)": {
+                "color_set_id": 4,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 12,
+                "ui_title": "(Tweak)"
+            },
+            "Arm.R (FK)": {
+                "color_set_id": 5,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 11,
+                "ui_title": "(FK)"
+            },
+            "Arm.R (IK)": {
+                "color_set_id": 2,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 10,
+                "ui_title": ""
+            },
+            "Arm.R (Tweak)": {
+                "color_set_id": 4,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 12,
+                "ui_title": "(Tweak)"
+            },
+            "DEF": {
+                "color_set_id": 0,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 0,
+                "ui_title": ""
+            },
+            "Face": {
+                "color_set_id": 5,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 1,
+                "ui_title": ""
+            },
+            "Face (Primary)": {
+                "color_set_id": 2,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 2,
+                "ui_title": "(Primary)"
+            },
+            "Face (Secondary)": {
+                "color_set_id": 3,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 2,
+                "ui_title": "(Secondary)"
+            },
+            "Fingers": {
+                "color_set_id": 6,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 7,
+                "ui_title": ""
+            },
+            "Fingers (Detail)": {
+                "color_set_id": 5,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 8,
+                "ui_title": "(Detail)"
+            },
+            "Leg.L (FK)": {
+                "color_set_id": 5,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 15,
+                "ui_title": "(FK)"
+            },
+            "Leg.L (IK)": {
+                "color_set_id": 2,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 14,
+                "ui_title": ""
+            },
+            "Leg.L (Tweak)": {
+                "color_set_id": 4,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 16,
+                "ui_title": "(Tweak)"
+            },
+            "Leg.R (FK)": {
+                "color_set_id": 5,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 15,
+                "ui_title": "(FK)"
+            },
+            "Leg.R (IK)": {
+                "color_set_id": 2,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 14,
+                "ui_title": ""
+            },
+            "Leg.R (Tweak)": {
+                "color_set_id": 4,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 16,
+                "ui_title": "(Tweak)"
+            },
+            "MCH": {
+                "color_set_id": 0,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 0,
+                "ui_title": ""
+            },
+            "Root": {
+                "color_set_id": 1,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 19,
+                "ui_title": ""
+            },
+            "Torso": {
+                "color_set_id": 3,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 4,
+                "ui_title": ""
+            },
+            "Torso (Tweak)": {
+                "color_set_id": 4,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 5,
+                "ui_title": "(Tweak)"
+            }
+        },
         "colors": [
             {
                 "name": "Root",
@@ -14515,217 +8156,7 @@
                 ]
             }
         ],
-        "layers": [
-            true,
-            true,
-            true,
-            true,
-            false,
-            true,
-            false,
-            true,
-            false,
-            false,
-            true,
-            false,
-            false,
-            true,
-            false,
-            false,
-            true,
-            false,
-            false,
-            true,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            true,
-            true,
-            false
-        ],
         "rigify_colors_lock": true,
-        "rigify_layers": [
-            {
-                "group": 5,
-                "name": "Face",
-                "row": 1,
-                "selset": false
-            },
-            {
-                "group": 2,
-                "name": "Face (Primary)",
-                "row": 2,
-                "selset": false
-            },
-            {
-                "group": 3,
-                "name": "Face (Secondary)",
-                "row": 2,
-                "selset": false
-            },
-            {
-                "group": 3,
-                "name": "Torso",
-                "row": 3,
-                "selset": false
-            },
-            {
-                "group": 4,
-                "name": "Torso (Tweak)",
-                "row": 4,
-                "selset": false
-            },
-            {
-                "group": 6,
-                "name": "Fingers",
-                "row": 5,
-                "selset": false
-            },
-            {
-                "group": 5,
-                "name": "Fingers (Detail)",
-                "row": 6,
-                "selset": false
-            },
-            {
-                "group": 2,
-                "name": "Arm.L (IK)",
-                "row": 7,
-                "selset": false
-            },
-            {
-                "group": 5,
-                "name": "Arm.L (FK)",
-                "row": 8,
-                "selset": false
-            },
-            {
-                "group": 4,
-                "name": "Arm.L (Tweak)",
-                "row": 9,
-                "selset": false
-            },
-            {
-                "group": 2,
-                "name": "Arm.R (IK)",
-                "row": 7,
-                "selset": false
-            },
-            {
-                "group": 5,
-                "name": "Arm.R (FK)",
-                "row": 8,
-                "selset": false
-            },
-            {
-                "group": 4,
-                "name": "Arm.R (Tweak)",
-                "row": 9,
-                "selset": false
-            },
-            {
-                "group": 2,
-                "name": "Leg.L (IK)",
-                "row": 10,
-                "selset": false
-            },
-            {
-                "group": 5,
-                "name": "Leg.L (FK)",
-                "row": 11,
-                "selset": false
-            },
-            {
-                "group": 4,
-                "name": "Leg.L (Tweak)",
-                "row": 12,
-                "selset": false
-            },
-            {
-                "group": 2,
-                "name": "Leg.R (IK)",
-                "row": 10,
-                "selset": false
-            },
-            {
-                "group": 5,
-                "name": "Leg.R (FK)",
-                "row": 11,
-                "selset": false
-            },
-            {
-                "group": 4,
-                "name": "Leg.R (Tweak)",
-                "row": 12,
-                "selset": false
-            },
-            {
-                "group": 6,
-                "name": "Toes",
-                "row": 13,
-                "selset": false
-            },
-            {
-                "group": 5,
-                "name": "Toes (Detail)",
-                "row": 14,
-                "selset": false
-            },
-            {
-                "group": 0,
-                "name": "",
-                "row": 1,
-                "selset": false
-            },
-            {
-                "group": 0,
-                "name": "",
-                "row": 1,
-                "selset": false
-            },
-            {
-                "group": 0,
-                "name": "",
-                "row": 1,
-                "selset": false
-            },
-            {
-                "group": 0,
-                "name": "",
-                "row": 1,
-                "selset": false
-            },
-            {
-                "group": 0,
-                "name": "",
-                "row": 1,
-                "selset": false
-            },
-            {
-                "group": 0,
-                "name": "",
-                "row": 1,
-                "selset": false
-            },
-            {
-                "group": 0,
-                "name": "",
-                "row": 1,
-                "selset": false
-            },
-            {
-                "group": 1,
-                "name": "Root",
-                "row": 14,
-                "selset": false
-            }
-        ],
         "selection_colors": {
             "active": [
                 0.5490000247955322,
@@ -14740,5 +8171,5 @@
         }
     },
     "scale_factor": 0.10000000149011612,
-    "version": 100
+    "version": 110
 }

--- a/src/mpfb/data/rigs/rigify/rig.human_toes.json
+++ b/src/mpfb/data/rigs/rigify/rig.human_toes.json
@@ -1,6 +1,9 @@
 {
     "bones": {
         "DEF-elbow-helper.L": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "name": "Armature@DEF-upper_arm.L.001@DEF",
@@ -85,40 +88,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "",
             "rigify": {
                 "rigify_parameters": {
@@ -141,6 +110,9 @@
             "use_local_location": true
         },
         "DEF-elbow-helper.R": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "name": "Armature@DEF-upper_arm.R.001@DEF",
@@ -225,40 +197,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "",
             "rigify": {
                 "rigify_parameters": {
@@ -281,6 +219,9 @@
             "use_local_location": true
         },
         "DEF-knee-helper.L": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "name": "Armature@DEF-thigh.L.001@DEF",
@@ -365,40 +306,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "",
             "rigify": {
                 "rigify_parameters": {
@@ -422,6 +329,9 @@
             "use_local_location": true
         },
         "DEF-knee-helper.R": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "name": "Armature@DEF-thigh.R.001@DEF",
@@ -506,40 +416,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "",
             "rigify": {
                 "rigify_parameters": {
@@ -563,6 +439,9 @@
             "use_local_location": true
         },
         "DEF-pelvis-helper.L": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "head_tail": 0.0,
@@ -698,40 +577,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "spine",
             "rigify": {
                 "rigify_parameters": {
@@ -768,6 +613,9 @@
             "use_local_location": true
         },
         "DEF-pelvis-helper.R": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "head_tail": 0.0,
@@ -903,40 +751,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "spine",
             "rigify": {
                 "rigify_parameters": {
@@ -973,6 +787,9 @@
             "use_local_location": true
         },
         "DEF-pelvis-helper.front.L": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "from_max_x": 0.0,
@@ -1150,40 +967,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "DEF-pelvis-helper.L",
             "rigify": {
                 "rigify_parameters": {
@@ -1220,6 +1003,9 @@
             "use_local_location": true
         },
         "DEF-pelvis-helper.front.R": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "from_max_x": 0.0,
@@ -1397,40 +1183,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "DEF-pelvis-helper.R",
             "rigify": {
                 "rigify_parameters": {
@@ -1467,6 +1219,9 @@
             "use_local_location": true
         },
         "DEF-shoulder-helper.L": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "head_tail": 0.0,
@@ -1602,40 +1357,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "shoulder.L",
             "rigify": {
                 "rigify_parameters": {
@@ -1672,6 +1393,9 @@
             "use_local_location": true
         },
         "DEF-shoulder-helper.R": {
+            "collections": [
+                "DEF"
+            ],
             "constraints": [
                 {
                     "head_tail": 0.0,
@@ -1807,40 +1531,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false
-            ],
             "parent": "shoulder.R",
             "rigify": {
                 "rigify_parameters": {
@@ -1877,6 +1567,9 @@
             "use_local_location": true
         },
         "MCH-breast-parent": {
+            "collections": [
+                "MCH"
+            ],
             "constraints": [
                 {
                     "name": "Armature@DEF",
@@ -1906,40 +1599,6 @@
                 "vertex_index": 1892
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false
-            ],
             "parent": "",
             "rigify": {
                 "rigify_parameters": {
@@ -1967,6 +1626,9 @@
             "use_local_location": true
         },
         "breast.L": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "default_position": [
                     0.07857,
@@ -1980,40 +1642,6 @@
                 ]
             },
             "inherit_scale": "AVERAGE",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "MCH-breast-parent",
             "rigify": {
                 "rigify_type": "basic.super_copy"
@@ -2034,6 +1662,9 @@
             "use_local_location": true
         },
         "breast.R": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "default_position": [
                     -0.07857,
@@ -2047,40 +1678,6 @@
                 ]
             },
             "inherit_scale": "AVERAGE",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "MCH-breast-parent",
             "rigify": {
                 "rigify_type": "basic.super_copy"
@@ -2101,6 +1698,9 @@
             "use_local_location": true
         },
         "brow.B.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.05155,
@@ -2111,40 +1711,6 @@
                 "vertex_index": 6964
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -2173,6 +1739,9 @@
             "use_local_location": true
         },
         "brow.B.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.04675,
@@ -2183,40 +1752,6 @@
                 "vertex_index": 6938
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.B.L",
             "rigify": {},
             "roll": 0.0,
@@ -2235,6 +1770,9 @@
             "use_local_location": true
         },
         "brow.B.L.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.03878,
@@ -2245,40 +1783,6 @@
                 "vertex_index": 6948
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.B.L.001",
             "rigify": {},
             "roll": 0.0,
@@ -2297,6 +1801,9 @@
             "use_local_location": true
         },
         "brow.B.L.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.02162,
@@ -2307,40 +1814,6 @@
                 "vertex_index": 6950
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.B.L.002",
             "rigify": {},
             "roll": 0.0,
@@ -2359,6 +1832,9 @@
             "use_local_location": true
         },
         "brow.B.L.004": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.01124,
@@ -2369,40 +1845,6 @@
                 "vertex_index": 6897
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -2434,6 +1876,9 @@
             "use_local_location": true
         },
         "brow.B.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.05155,
@@ -2444,40 +1889,6 @@
                 "vertex_index": 188
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -2506,6 +1917,9 @@
             "use_local_location": true
         },
         "brow.B.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.04675,
@@ -2516,40 +1930,6 @@
                 "vertex_index": 160
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.B.R",
             "rigify": {},
             "roll": 0.0,
@@ -2568,6 +1948,9 @@
             "use_local_location": true
         },
         "brow.B.R.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.03878,
@@ -2578,40 +1961,6 @@
                 "vertex_index": 172
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.B.R.001",
             "rigify": {},
             "roll": 0.0,
@@ -2630,6 +1979,9 @@
             "use_local_location": true
         },
         "brow.B.R.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.02162,
@@ -2640,40 +1992,6 @@
                 "vertex_index": 174
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.B.R.002",
             "rigify": {},
             "roll": 0.0,
@@ -2692,6 +2010,9 @@
             "use_local_location": true
         },
         "brow.B.R.004": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.01124,
@@ -2702,40 +2023,6 @@
                 "vertex_index": 113
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -2767,6 +2054,9 @@
             "use_local_location": true
         },
         "brow.T.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.05856,
@@ -2777,40 +2067,6 @@
                 "vertex_index": 7032
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -2838,6 +2094,9 @@
             "use_local_location": true
         },
         "brow.T.L.001": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     0.05421,
@@ -2848,40 +2107,6 @@
                 "vertex_index": 7023
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -2909,6 +2134,9 @@
             "use_local_location": true
         },
         "brow.T.L.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.03984,
@@ -2919,40 +2147,6 @@
                 "vertex_index": 6981
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.T.L.001",
             "rigify": {},
             "roll": 0.0,
@@ -2971,6 +2165,9 @@
             "use_local_location": true
         },
         "brow.T.L.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.01521,
@@ -2981,40 +2178,6 @@
                 "vertex_index": 6983
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3042,6 +2205,9 @@
             "use_local_location": true
         },
         "brow.T.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.05856,
@@ -3052,40 +2218,6 @@
                 "vertex_index": 263
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3113,6 +2245,9 @@
             "use_local_location": true
         },
         "brow.T.R.001": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     -0.05421,
@@ -3123,40 +2258,6 @@
                 "vertex_index": 254
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3184,6 +2285,9 @@
             "use_local_location": true
         },
         "brow.T.R.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.03984,
@@ -3194,40 +2298,6 @@
                 "vertex_index": 206
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.T.R.001",
             "rigify": {},
             "roll": 0.0,
@@ -3246,6 +2316,9 @@
             "use_local_location": true
         },
         "brow.T.R.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.01521,
@@ -3256,40 +2329,6 @@
                 "vertex_index": 208
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3317,6 +2356,9 @@
             "use_local_location": true
         },
         "brow_glue.B.L.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.03878,
@@ -3327,40 +2369,6 @@
                 "vertex_index": 6948
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3387,6 +2395,9 @@
             "use_local_location": true
         },
         "brow_glue.B.R.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.03878,
@@ -3397,40 +2408,6 @@
                 "vertex_index": 172
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3457,6 +2434,9 @@
             "use_local_location": true
         },
         "cheek.B.L": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     0.02282,
@@ -3470,40 +2450,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3530,6 +2476,9 @@
             "use_local_location": true
         },
         "cheek.B.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.05094,
@@ -3540,40 +2489,6 @@
                 "vertex_index": 11767
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "cheek.B.L",
             "rigify": {},
             "roll": -3.91226,
@@ -3591,6 +2506,9 @@
             "use_local_location": true
         },
         "cheek.B.R": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     -0.02282,
@@ -3604,40 +2522,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3664,6 +2548,9 @@
             "use_local_location": true
         },
         "cheek.B.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.05094,
@@ -3674,40 +2561,6 @@
                 "vertex_index": 5153
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "cheek.B.R",
             "rigify": {},
             "roll": 3.91226,
@@ -3725,6 +2578,9 @@
             "use_local_location": true
         },
         "cheek.T.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.05856,
@@ -3735,40 +2591,6 @@
                 "vertex_index": 7032
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3792,6 +2614,9 @@
             "use_local_location": true
         },
         "cheek.T.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.04235,
@@ -3802,40 +2627,6 @@
                 "vertex_index": 11748
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "cheek.T.L",
             "rigify": {},
             "roll": 0.0,
@@ -3854,6 +2645,9 @@
             "use_local_location": true
         },
         "cheek.T.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.05856,
@@ -3864,40 +2658,6 @@
                 "vertex_index": 263
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -3921,6 +2681,9 @@
             "use_local_location": true
         },
         "cheek.T.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.04235,
@@ -3931,40 +2694,6 @@
                 "vertex_index": 5133
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "cheek.T.R",
             "rigify": {},
             "roll": 0.0,
@@ -3983,6 +2712,9 @@
             "use_local_location": true
         },
         "cheek_glue.T.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.04235,
@@ -3993,40 +2725,6 @@
                 "vertex_index": 11748
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -4053,6 +2751,9 @@
             "use_local_location": true
         },
         "cheek_glue.T.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.04235,
@@ -4063,40 +2764,6 @@
                 "vertex_index": 5133
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -4123,6 +2790,9 @@
             "use_local_location": true
         },
         "chin": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -4133,40 +2803,6 @@
                 "vertex_index": 5225
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -4193,6 +2829,9 @@
             "use_local_location": true
         },
         "chin.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -4203,40 +2842,6 @@
                 "vertex_index": 5162
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "chin",
             "rigify": {},
             "roll": 0.0,
@@ -4254,6 +2859,9 @@
             "use_local_location": true
         },
         "chin.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.02626,
@@ -4264,40 +2872,6 @@
                 "vertex_index": 11833
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw.L.001",
             "rigify": {},
             "roll": 2.19646,
@@ -4318,6 +2892,9 @@
             "use_local_location": true
         },
         "chin.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.02626,
@@ -4328,40 +2905,6 @@
                 "vertex_index": 5223
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw.R.001",
             "rigify": {},
             "roll": -2.19646,
@@ -4382,6 +2925,9 @@
             "use_local_location": true
         },
         "chin_end_glue.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -4392,40 +2938,6 @@
                 "vertex_index": 491
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -4455,6 +2967,9 @@
             "use_local_location": true
         },
         "ear.L": {
+            "collections": [
+                "Face"
+            ],
             "head": {
                 "default_position": [
                     0.06924,
@@ -4465,40 +2980,6 @@
                 "vertex_index": 12020
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -4521,6 +3002,9 @@
             "use_local_location": true
         },
         "ear.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.07043,
@@ -4531,40 +3015,6 @@
                 "vertex_index": 12165
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "ear.L",
             "rigify": {
                 "rigify_parameters": {
@@ -4594,6 +3044,9 @@
             "use_local_location": true
         },
         "ear.L.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0788,
@@ -4607,40 +3060,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "ear.L",
             "rigify": {
                 "rigify_parameters": {
@@ -4670,6 +3089,9 @@
             "use_local_location": true
         },
         "ear.L.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.07883,
@@ -4683,40 +3105,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "ear.L.002",
             "rigify": {},
             "roll": 0.74592,
@@ -4737,6 +3125,9 @@
             "use_local_location": true
         },
         "ear.L.004": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.07314,
@@ -4750,40 +3141,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "ear.L",
             "rigify": {
                 "rigify_parameters": {
@@ -4810,6 +3167,9 @@
             "use_local_location": true
         },
         "ear.R": {
+            "collections": [
+                "Face"
+            ],
             "head": {
                 "default_position": [
                     -0.06924,
@@ -4820,40 +3180,6 @@
                 "vertex_index": 5421
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -4876,6 +3202,9 @@
             "use_local_location": true
         },
         "ear.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.07043,
@@ -4886,40 +3215,6 @@
                 "vertex_index": 5568
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "ear.R",
             "rigify": {
                 "rigify_parameters": {
@@ -4949,6 +3244,9 @@
             "use_local_location": true
         },
         "ear.R.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.0788,
@@ -4962,40 +3260,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "ear.R",
             "rigify": {
                 "rigify_parameters": {
@@ -5025,6 +3289,9 @@
             "use_local_location": true
         },
         "ear.R.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.07883,
@@ -5038,40 +3305,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "ear.R.002",
             "rigify": {},
             "roll": -0.74592,
@@ -5092,6 +3325,9 @@
             "use_local_location": true
         },
         "ear.R.004": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.07314,
@@ -5105,40 +3341,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "ear.R",
             "rigify": {
                 "rigify_parameters": {
@@ -5165,6 +3367,9 @@
             "use_local_location": true
         },
         "eye.L": {
+            "collections": [
+                "Face"
+            ],
             "head": {
                 "cube_name": "joint-l-eye",
                 "default_position": [
@@ -5175,40 +3380,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_type": "face.skin_eye"
@@ -5232,6 +3403,9 @@
             "use_local_location": true
         },
         "eye.R": {
+            "collections": [
+                "Face"
+            ],
             "head": {
                 "cube_name": "joint-r-eye",
                 "default_position": [
@@ -5242,40 +3416,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_type": "face.skin_eye"
@@ -5299,6 +3439,9 @@
             "use_local_location": true
         },
         "f_index.01.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-2-1",
                 "default_position": [
@@ -5309,77 +3452,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.01.L",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -5400,6 +3478,9 @@
             "use_local_location": true
         },
         "f_index.01.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-2-1",
                 "default_position": [
@@ -5410,77 +3491,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.01.R",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -5501,6 +3517,9 @@
             "use_local_location": true
         },
         "f_index.02.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-2-2",
                 "default_position": [
@@ -5511,40 +3530,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_index.01.L",
             "rigify": {},
             "roll": -0.81155,
@@ -5563,6 +3548,9 @@
             "use_local_location": true
         },
         "f_index.02.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-2-2",
                 "default_position": [
@@ -5573,40 +3561,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_index.01.R",
             "rigify": {},
             "roll": 0.81155,
@@ -5625,6 +3579,9 @@
             "use_local_location": true
         },
         "f_index.03.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-2-3",
                 "default_position": [
@@ -5635,40 +3592,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_index.02.L",
             "rigify": {},
             "roll": -0.56598,
@@ -5687,6 +3610,9 @@
             "use_local_location": true
         },
         "f_index.03.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-2-3",
                 "default_position": [
@@ -5697,40 +3623,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_index.02.R",
             "rigify": {},
             "roll": 0.56598,
@@ -5749,6 +3641,9 @@
             "use_local_location": true
         },
         "f_middle.01.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-3-1",
                 "default_position": [
@@ -5759,77 +3654,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.02.L",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -5850,6 +3680,9 @@
             "use_local_location": true
         },
         "f_middle.01.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-3-1",
                 "default_position": [
@@ -5860,77 +3693,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.02.R",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -5951,6 +3719,9 @@
             "use_local_location": true
         },
         "f_middle.02.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-3-2",
                 "default_position": [
@@ -5961,40 +3732,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_middle.01.L",
             "rigify": {},
             "roll": -1.27877,
@@ -6013,6 +3750,9 @@
             "use_local_location": true
         },
         "f_middle.02.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-3-2",
                 "default_position": [
@@ -6023,40 +3763,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_middle.01.R",
             "rigify": {},
             "roll": 1.27877,
@@ -6075,6 +3781,9 @@
             "use_local_location": true
         },
         "f_middle.03.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-3-3",
                 "default_position": [
@@ -6085,40 +3794,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_middle.02.L",
             "rigify": {},
             "roll": -1.05372,
@@ -6137,6 +3812,9 @@
             "use_local_location": true
         },
         "f_middle.03.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-3-3",
                 "default_position": [
@@ -6147,40 +3825,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_middle.02.R",
             "rigify": {},
             "roll": 1.05372,
@@ -6199,6 +3843,9 @@
             "use_local_location": true
         },
         "f_pinky.01.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-5-1",
                 "default_position": [
@@ -6209,77 +3856,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.04.L",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -6300,6 +3882,9 @@
             "use_local_location": true
         },
         "f_pinky.01.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-5-1",
                 "default_position": [
@@ -6310,77 +3895,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.04.R",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -6401,6 +3921,9 @@
             "use_local_location": true
         },
         "f_pinky.02.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-5-2",
                 "default_position": [
@@ -6411,40 +3934,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_pinky.01.L",
             "rigify": {},
             "roll": -1.37208,
@@ -6463,6 +3952,9 @@
             "use_local_location": true
         },
         "f_pinky.02.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-5-2",
                 "default_position": [
@@ -6473,40 +3965,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_pinky.01.R",
             "rigify": {},
             "roll": 1.37208,
@@ -6525,6 +3983,9 @@
             "use_local_location": true
         },
         "f_pinky.03.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-5-3",
                 "default_position": [
@@ -6535,40 +3996,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_pinky.02.L",
             "rigify": {},
             "roll": -1.39831,
@@ -6587,6 +4014,9 @@
             "use_local_location": true
         },
         "f_pinky.03.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-5-3",
                 "default_position": [
@@ -6597,40 +4027,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_pinky.02.R",
             "rigify": {},
             "roll": 1.39831,
@@ -6649,6 +4045,9 @@
             "use_local_location": true
         },
         "f_ring.01.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-4-1",
                 "default_position": [
@@ -6659,77 +4058,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.03.L",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -6750,6 +4084,9 @@
             "use_local_location": true
         },
         "f_ring.01.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-4-1",
                 "default_position": [
@@ -6760,77 +4097,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.03.R",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -6851,6 +4123,9 @@
             "use_local_location": true
         },
         "f_ring.02.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-4-2",
                 "default_position": [
@@ -6861,40 +4136,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_ring.01.L",
             "rigify": {},
             "roll": -1.44243,
@@ -6913,6 +4154,9 @@
             "use_local_location": true
         },
         "f_ring.02.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-4-2",
                 "default_position": [
@@ -6923,40 +4167,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_ring.01.R",
             "rigify": {},
             "roll": 1.44243,
@@ -6975,6 +4185,9 @@
             "use_local_location": true
         },
         "f_ring.03.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-4-3",
                 "default_position": [
@@ -6985,40 +4198,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_ring.02.L",
             "rigify": {},
             "roll": -1.28095,
@@ -7037,6 +4216,9 @@
             "use_local_location": true
         },
         "f_ring.03.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-4-3",
                 "default_position": [
@@ -7047,40 +4229,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "f_ring.02.R",
             "rigify": {},
             "roll": 1.28095,
@@ -7099,6 +4247,11 @@
             "use_local_location": true
         },
         "face": {
+            "collections": [
+                "Face",
+                "Face (Primary)",
+                "Face (Secondary)"
+            ],
             "head": {
                 "cube_name": "joint-head",
                 "default_position": [
@@ -7109,76 +4262,11 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                true,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine.006",
             "rigify": {
                 "rigify_parameters": {
-                    "secondary_layers": [
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "secondary_coll_refs": [
+                        "Face (Secondary)"
                     ]
                 }
             },
@@ -7202,6 +4290,9 @@
             "use_local_location": true
         },
         "foot.L": {
+            "collections": [
+                "Leg.L (IK)"
+            ],
             "head": {
                 "cube_name": "joint-l-ankle",
                 "default_position": [
@@ -7212,40 +4303,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "shin.L",
             "rigify": {},
             "roll": 0.0,
@@ -7265,6 +4322,9 @@
             "use_local_location": true
         },
         "foot.R": {
+            "collections": [
+                "Leg.R (IK)"
+            ],
             "head": {
                 "cube_name": "joint-r-ankle",
                 "default_position": [
@@ -7275,40 +4335,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "shin.R",
             "rigify": {},
             "roll": 0.0,
@@ -7328,6 +4354,9 @@
             "use_local_location": true
         },
         "forearm.L": {
+            "collections": [
+                "Arm.L (IK)"
+            ],
             "head": {
                 "cube_name": "joint-l-elbow",
                 "default_position": [
@@ -7338,40 +4367,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "upper_arm.L",
             "rigify": {},
             "roll": 2.1535,
@@ -7390,6 +4385,9 @@
             "use_local_location": true
         },
         "forearm.R": {
+            "collections": [
+                "Arm.R (IK)"
+            ],
             "head": {
                 "cube_name": "joint-r-elbow",
                 "default_position": [
@@ -7400,40 +4398,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "upper_arm.R",
             "rigify": {},
             "roll": -2.1535,
@@ -7452,6 +4416,9 @@
             "use_local_location": true
         },
         "forehead.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.00814,
@@ -7462,40 +4429,6 @@
                 "vertex_index": 7015
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -7518,6 +4451,9 @@
             "use_local_location": true
         },
         "forehead.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0282,
@@ -7528,40 +4464,6 @@
                 "vertex_index": 7011
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -7584,6 +4486,9 @@
             "use_local_location": true
         },
         "forehead.L.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.04982,
@@ -7594,40 +4499,6 @@
                 "vertex_index": 7018
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -7650,6 +4521,9 @@
             "use_local_location": true
         },
         "forehead.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.00814,
@@ -7660,40 +4534,6 @@
                 "vertex_index": 245
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -7716,6 +4556,9 @@
             "use_local_location": true
         },
         "forehead.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.0282,
@@ -7726,40 +4569,6 @@
                 "vertex_index": 240
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -7782,6 +4591,9 @@
             "use_local_location": true
         },
         "forehead.R.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.04982,
@@ -7792,40 +4604,6 @@
                 "vertex_index": 248
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -7848,6 +4626,9 @@
             "use_local_location": true
         },
         "hand.L": {
+            "collections": [
+                "Arm.L (IK)"
+            ],
             "head": {
                 "cube_name": "joint-l-hand",
                 "default_position": [
@@ -7858,40 +4639,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "forearm.L",
             "rigify": {},
             "roll": 2.2103,
@@ -7910,6 +4657,9 @@
             "use_local_location": true
         },
         "hand.R": {
+            "collections": [
+                "Arm.R (IK)"
+            ],
             "head": {
                 "cube_name": "joint-r-hand",
                 "default_position": [
@@ -7920,40 +4670,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "forearm.R",
             "rigify": {},
             "roll": -2.2103,
@@ -7972,6 +4688,9 @@
             "use_local_location": true
         },
         "heel.02.L": {
+            "collections": [
+                "Leg.L (IK)"
+            ],
             "head": {
                 "default_position": [
                     0.14959,
@@ -7986,40 +4705,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "foot.L",
             "rigify": {},
             "roll": 0.0,
@@ -8041,6 +4726,9 @@
             "use_local_location": true
         },
         "heel.02.R": {
+            "collections": [
+                "Leg.R (IK)"
+            ],
             "head": {
                 "default_position": [
                     -0.14959,
@@ -8055,40 +4743,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "foot.R",
             "rigify": {},
             "roll": 0.0,
@@ -8110,6 +4764,9 @@
             "use_local_location": true
         },
         "jaw": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -8120,40 +4777,6 @@
                 "vertex_index": 783
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -8180,6 +4803,9 @@
             "use_local_location": true
         },
         "jaw.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.06545,
@@ -8190,40 +4816,6 @@
                 "vertex_index": 11712
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -8250,6 +4842,9 @@
             "use_local_location": true
         },
         "jaw.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.05626,
@@ -8260,40 +4855,6 @@
                 "vertex_index": 7597
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw.L",
             "rigify": {},
             "roll": -1.72746,
@@ -8311,6 +4872,9 @@
             "use_local_location": true
         },
         "jaw.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.06545,
@@ -8321,40 +4885,6 @@
                 "vertex_index": 5097
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -8381,6 +4911,9 @@
             "use_local_location": true
         },
         "jaw.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.05626,
@@ -8391,40 +4924,6 @@
                 "vertex_index": 895
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw.R",
             "rigify": {},
             "roll": 1.72746,
@@ -8442,6 +4941,9 @@
             "use_local_location": true
         },
         "jaw_master": {
+            "collections": [
+                "Face"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -8455,40 +4957,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -8511,6 +4979,9 @@
             "use_local_location": true
         },
         "lid.B.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.04325,
@@ -8521,78 +4992,13 @@
                 "vertex_index": 6806
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "eye.L",
             "rigify": {
                 "rigify_parameters": {
                     "skin_chain_pivot_pos": 2,
                     "skin_control_orientation_bone": "face",
-                    "skin_secondary_layers": [
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "skin_secondary_coll_refs": [
+                        "Face (Primary)"
                     ],
                     "skin_secondary_layers_extra": true
                 },
@@ -8614,6 +5020,9 @@
             "use_local_location": true
         },
         "lid.B.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.03956,
@@ -8624,40 +5033,6 @@
                 "vertex_index": 6818
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.B.L",
             "rigify": {},
             "roll": 0.0,
@@ -8676,6 +5051,9 @@
             "use_local_location": true
         },
         "lid.B.L.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.02949,
@@ -8686,40 +5064,6 @@
                 "vertex_index": 6827
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.B.L.001",
             "rigify": {},
             "roll": 0.0,
@@ -8738,6 +5082,9 @@
             "use_local_location": true
         },
         "lid.B.L.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0222,
@@ -8748,40 +5095,6 @@
                 "vertex_index": 6833
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.B.L.002",
             "rigify": {},
             "roll": 0.0,
@@ -8800,6 +5113,9 @@
             "use_local_location": true
         },
         "lid.B.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.04325,
@@ -8810,78 +5126,13 @@
                 "vertex_index": 22
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "eye.R",
             "rigify": {
                 "rigify_parameters": {
                     "skin_chain_pivot_pos": 2,
                     "skin_control_orientation_bone": "face",
-                    "skin_secondary_layers": [
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "skin_secondary_coll_refs": [
+                        "Face (Primary)"
                     ],
                     "skin_secondary_layers_extra": true
                 },
@@ -8903,6 +5154,9 @@
             "use_local_location": true
         },
         "lid.B.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.03956,
@@ -8913,40 +5167,6 @@
                 "vertex_index": 34
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.B.R",
             "rigify": {},
             "roll": 0.0,
@@ -8965,6 +5185,9 @@
             "use_local_location": true
         },
         "lid.B.R.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.02949,
@@ -8975,40 +5198,6 @@
                 "vertex_index": 43
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.B.R.001",
             "rigify": {},
             "roll": 0.0,
@@ -9027,6 +5216,9 @@
             "use_local_location": true
         },
         "lid.B.R.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.0222,
@@ -9037,40 +5229,6 @@
                 "vertex_index": 49
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.B.R.002",
             "rigify": {},
             "roll": 0.0,
@@ -9089,6 +5247,9 @@
             "use_local_location": true
         },
         "lid.T.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.01556,
@@ -9099,40 +5260,6 @@
                 "vertex_index": 6851
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "eye.L",
             "rigify": {
                 "rigify_parameters": {
@@ -9143,39 +5270,8 @@
                     ],
                     "skin_chain_pivot_pos": 2,
                     "skin_control_orientation_bone": "face",
-                    "skin_secondary_layers": [
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "skin_secondary_coll_refs": [
+                        "Face (Primary)"
                     ],
                     "skin_secondary_layers_extra": true
                 },
@@ -9197,6 +5293,9 @@
             "use_local_location": true
         },
         "lid.T.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.02179,
@@ -9207,40 +5306,6 @@
                 "vertex_index": 6842
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.T.L",
             "rigify": {},
             "roll": 0.0,
@@ -9259,6 +5324,9 @@
             "use_local_location": true
         },
         "lid.T.L.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.02914,
@@ -9269,40 +5337,6 @@
                 "vertex_index": 6787
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.T.L.001",
             "rigify": {},
             "roll": 0.0,
@@ -9321,6 +5355,9 @@
             "use_local_location": true
         },
         "lid.T.L.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.03916,
@@ -9331,40 +5368,6 @@
                 "vertex_index": 6794
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.T.L.002",
             "rigify": {},
             "roll": 0.0,
@@ -9383,6 +5386,9 @@
             "use_local_location": true
         },
         "lid.T.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.01556,
@@ -9393,40 +5399,6 @@
                 "vertex_index": 67
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "eye.R",
             "rigify": {
                 "rigify_parameters": {
@@ -9437,39 +5409,8 @@
                     ],
                     "skin_chain_pivot_pos": 2,
                     "skin_control_orientation_bone": "face",
-                    "skin_secondary_layers": [
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "skin_secondary_coll_refs": [
+                        "Face (Primary)"
                     ],
                     "skin_secondary_layers_extra": true
                 },
@@ -9491,6 +5432,9 @@
             "use_local_location": true
         },
         "lid.T.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.02179,
@@ -9501,40 +5445,6 @@
                 "vertex_index": 58
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.T.R",
             "rigify": {},
             "roll": 0.0,
@@ -9553,6 +5463,9 @@
             "use_local_location": true
         },
         "lid.T.R.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.02914,
@@ -9563,40 +5476,6 @@
                 "vertex_index": 3
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.T.R.001",
             "rigify": {},
             "roll": 0.0,
@@ -9615,6 +5494,9 @@
             "use_local_location": true
         },
         "lid.T.R.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.03916,
@@ -9625,40 +5507,6 @@
                 "vertex_index": 10
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lid.T.R.002",
             "rigify": {},
             "roll": 0.0,
@@ -9677,6 +5525,9 @@
             "use_local_location": true
         },
         "lid_glue.B.L.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.02949,
@@ -9687,40 +5538,6 @@
                 "vertex_index": 6827
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -9747,6 +5564,9 @@
             "use_local_location": true
         },
         "lid_glue.B.R.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.02949,
@@ -9757,40 +5577,6 @@
                 "vertex_index": 43
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -9817,6 +5603,9 @@
             "use_local_location": true
         },
         "lip.B.L": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -9830,40 +5619,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -9911,6 +5666,9 @@
             "use_local_location": true
         },
         "lip.B.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.01172,
@@ -9924,40 +5682,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lip.B.L",
             "rigify": {},
             "roll": 0.0,
@@ -9979,6 +5703,9 @@
             "use_local_location": true
         },
         "lip.B.R": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -9992,40 +5719,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -10073,6 +5766,9 @@
             "use_local_location": true
         },
         "lip.B.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.01172,
@@ -10086,40 +5782,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lip.B.R",
             "rigify": {},
             "roll": 0.0,
@@ -10141,6 +5803,9 @@
             "use_local_location": true
         },
         "lip.T.L": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -10154,40 +5819,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -10235,6 +5866,9 @@
             "use_local_location": true
         },
         "lip.T.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.01219,
@@ -10248,40 +5882,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lip.T.L",
             "rigify": {},
             "roll": 0.0,
@@ -10303,6 +5903,9 @@
             "use_local_location": true
         },
         "lip.T.R": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -10316,40 +5919,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -10397,6 +5966,9 @@
             "use_local_location": true
         },
         "lip.T.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.01219,
@@ -10410,40 +5982,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "lip.T.R",
             "rigify": {},
             "roll": 0.0,
@@ -10465,6 +6003,9 @@
             "use_local_location": true
         },
         "nose": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -10475,40 +6016,6 @@
                 "vertex_index": 132
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -10536,6 +6043,9 @@
             "use_local_location": true
         },
         "nose.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -10546,40 +6056,6 @@
                 "vertex_index": 164
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "nose",
             "rigify": {},
             "roll": 0.0,
@@ -10597,6 +6073,9 @@
             "use_local_location": true
         },
         "nose.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -10607,40 +6086,6 @@
                 "vertex_index": 297
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "nose_master",
             "rigify": {
                 "rigify_parameters": {
@@ -10668,6 +6113,9 @@
             "use_local_location": true
         },
         "nose.003": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -10678,40 +6126,6 @@
                 "vertex_index": 312
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "nose.002",
             "rigify": {},
             "roll": 0.0,
@@ -10729,6 +6143,9 @@
             "use_local_location": true
         },
         "nose.004": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -10739,40 +6156,6 @@
                 "vertex_index": 343
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -10799,6 +6182,9 @@
             "use_local_location": true
         },
         "nose.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.01212,
@@ -10809,40 +6195,6 @@
                 "vertex_index": 11715
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.B.L.004",
             "rigify": {},
             "roll": -1.81298,
@@ -10860,6 +6212,9 @@
             "use_local_location": true
         },
         "nose.L.001": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     0.0171,
@@ -10870,40 +6225,6 @@
                 "vertex_index": 7099
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "nose_master",
             "rigify": {
                 "rigify_parameters": {
@@ -10927,6 +6248,9 @@
             "use_local_location": true
         },
         "nose.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.01212,
@@ -10937,40 +6261,6 @@
                 "vertex_index": 5100
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "brow.B.R.004",
             "rigify": {},
             "roll": 1.81298,
@@ -10988,6 +6278,9 @@
             "use_local_location": true
         },
         "nose.R.001": {
+            "collections": [
+                "Face (Primary)"
+            ],
             "head": {
                 "default_position": [
                     -0.0171,
@@ -10998,40 +6291,6 @@
                 "vertex_index": 337
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "nose_master",
             "rigify": {
                 "rigify_parameters": {
@@ -11055,6 +6314,9 @@
             "use_local_location": true
         },
         "nose_end_glue.004": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -11065,40 +6327,6 @@
                 "vertex_index": 5342
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -11128,6 +6356,9 @@
             "use_local_location": true
         },
         "nose_glue.004": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -11138,40 +6369,6 @@
                 "vertex_index": 343
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -11201,6 +6398,9 @@
             "use_local_location": true
         },
         "nose_glue.L.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.0171,
@@ -11211,40 +6411,6 @@
                 "vertex_index": 7099
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -11274,6 +6440,9 @@
             "use_local_location": true
         },
         "nose_glue.R.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.0171,
@@ -11284,40 +6453,6 @@
                 "vertex_index": 337
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -11347,6 +6482,9 @@
             "use_local_location": true
         },
         "nose_master": {
+            "collections": [
+                "Face"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -11360,40 +6498,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -11425,6 +6529,9 @@
             "use_local_location": true
         },
         "palm.01.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-1-1",
                 "default_position": [
@@ -11435,40 +6542,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "hand.L",
             "rigify": {
                 "rigify_type": "limbs.super_palm"
@@ -11488,6 +6561,9 @@
             "use_local_location": true
         },
         "palm.01.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-1-1",
                 "default_position": [
@@ -11498,40 +6574,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "hand.R",
             "rigify": {
                 "rigify_type": "limbs.super_palm"
@@ -11551,6 +6593,9 @@
             "use_local_location": true
         },
         "palm.02.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-hand-3",
                 "default_position": [
@@ -11561,40 +6606,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "hand.L",
             "rigify": {},
             "roll": -2.29223,
@@ -11612,6 +6623,9 @@
             "use_local_location": true
         },
         "palm.02.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-hand-3",
                 "default_position": [
@@ -11622,40 +6636,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "hand.R",
             "rigify": {},
             "roll": 2.29223,
@@ -11673,6 +6653,9 @@
             "use_local_location": true
         },
         "palm.03.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "default_position": [
                     0.47306,
@@ -11686,40 +6669,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "hand.L",
             "rigify": {},
             "roll": -2.36717,
@@ -11737,6 +6686,9 @@
             "use_local_location": true
         },
         "palm.03.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "default_position": [
                     -0.47306,
@@ -11750,40 +6702,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "hand.R",
             "rigify": {},
             "roll": 2.36717,
@@ -11801,6 +6719,9 @@
             "use_local_location": true
         },
         "palm.04.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "default_position": [
                     0.477,
@@ -11814,40 +6735,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "hand.L",
             "rigify": {},
             "roll": -2.24642,
@@ -11865,6 +6752,9 @@
             "use_local_location": true
         },
         "palm.04.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "default_position": [
                     -0.477,
@@ -11878,40 +6768,6 @@
                 ]
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "hand.R",
             "rigify": {},
             "roll": 2.24642,
@@ -11929,6 +6785,9 @@
             "use_local_location": true
         },
         "pelvis.L": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-pelvis",
                 "default_position": [
@@ -11939,40 +6798,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine",
             "rigify": {
                 "rigify_parameters": {
@@ -11996,6 +6821,9 @@
             "use_local_location": true
         },
         "pelvis.R": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-pelvis",
                 "default_position": [
@@ -12006,40 +6834,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine",
             "rigify": {
                 "rigify_parameters": {
@@ -12063,6 +6857,9 @@
             "use_local_location": true
         },
         "shin.L": {
+            "collections": [
+                "Leg.L (IK)"
+            ],
             "head": {
                 "cube_name": "joint-l-knee",
                 "default_position": [
@@ -12073,40 +6870,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "thigh.L",
             "rigify": {},
             "roll": 0.0,
@@ -12126,6 +6889,9 @@
             "use_local_location": true
         },
         "shin.R": {
+            "collections": [
+                "Leg.R (IK)"
+            ],
             "head": {
                 "cube_name": "joint-r-knee",
                 "default_position": [
@@ -12136,40 +6902,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "thigh.R",
             "rigify": {},
             "roll": 0.0,
@@ -12189,6 +6921,9 @@
             "use_local_location": true
         },
         "shoulder.L": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-l-clavicle",
                 "default_position": [
@@ -12199,40 +6934,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine.004",
             "rigify": {
                 "rigify_parameters": {
@@ -12258,6 +6959,9 @@
             "use_local_location": true
         },
         "shoulder.R": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-r-clavicle",
                 "default_position": [
@@ -12268,40 +6972,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine.004",
             "rigify": {
                 "rigify_parameters": {
@@ -12327,6 +6997,9 @@
             "use_local_location": true
         },
         "spine": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -12337,110 +7010,14 @@
                 "vertex_index": 4374
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "",
             "rigify": {
                 "rigify_parameters": {
-                    "fk_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "fk_coll_refs": [
+                        "Torso (Tweak)"
                     ],
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Torso (Tweak)"
                     ]
                 },
                 "rigify_type": "spines.basic_spine"
@@ -12461,6 +7038,9 @@
             "use_local_location": true
         },
         "spine.001": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-spine-4",
                 "default_position": [
@@ -12471,40 +7051,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine",
             "rigify": {},
             "roll": 0.0,
@@ -12523,6 +7069,9 @@
             "use_local_location": true
         },
         "spine.002": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-spine-3",
                 "default_position": [
@@ -12533,40 +7082,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine.001",
             "rigify": {},
             "roll": 0.0,
@@ -12585,6 +7100,9 @@
             "use_local_location": true
         },
         "spine.003": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-spine-2",
                 "default_position": [
@@ -12595,40 +7113,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine.002",
             "rigify": {},
             "roll": 0.0,
@@ -12647,6 +7131,9 @@
             "use_local_location": true
         },
         "spine.004": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-spine-1",
                 "default_position": [
@@ -12657,40 +7144,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine.003",
             "rigify": {},
             "roll": 0.0,
@@ -12709,6 +7162,9 @@
             "use_local_location": true
         },
         "spine.005": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-neck",
                 "default_position": [
@@ -12719,77 +7175,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine.004",
             "rigify": {
                 "rigify_parameters": {
                     "connect_chain": true,
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Torso (Tweak)"
                     ]
                 },
                 "rigify_type": "spines.super_head"
@@ -12809,6 +7200,9 @@
             "use_local_location": true
         },
         "spine.006": {
+            "collections": [
+                "Torso"
+            ],
             "head": {
                 "cube_name": "joint-head",
                 "default_position": [
@@ -12819,40 +7213,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine.005",
             "rigify": {},
             "roll": 0.0,
@@ -12870,6 +7230,9 @@
             "use_local_location": true
         },
         "teeth.B": {
+            "collections": [
+                "Face"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -12880,40 +7243,6 @@
                 "vertex_index": 15012
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_parameters": {
@@ -12939,6 +7268,9 @@
             "use_local_location": true
         },
         "teeth.T": {
+            "collections": [
+                "Face"
+            ],
             "head": {
                 "default_position": [
                     0.0,
@@ -12949,40 +7281,6 @@
                 "vertex_index": 15079
             },
             "inherit_scale": "FULL",
-            "layers": [
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -13008,6 +7306,9 @@
             "use_local_location": true
         },
         "temple.L": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     0.06534,
@@ -13018,40 +7319,6 @@
                 "vertex_index": 12159
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -13075,6 +7342,9 @@
             "use_local_location": true
         },
         "temple.R": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "default_position": [
                     -0.06534,
@@ -13085,40 +7355,6 @@
                 "vertex_index": 5562
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "face",
             "rigify": {
                 "rigify_parameters": {
@@ -13142,6 +7378,9 @@
             "use_local_location": true
         },
         "thigh.L": {
+            "collections": [
+                "Leg.L (IK)"
+            ],
             "head": {
                 "cube_name": "joint-l-upper-leg",
                 "default_position": [
@@ -13152,115 +7391,19 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine",
             "rigify": {
                 "rigify_parameters": {
                     "auto_align_extremity": true,
                     "extra_ik_toe": true,
-                    "fk_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "fk_coll_refs": [
+                        "Leg.L (FK)"
                     ],
                     "ik_local_location": false,
                     "limb_type": "leg",
                     "rotation_axis": "x",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Leg.L (Tweak)"
                     ]
                 },
                 "rigify_type": "limbs.super_limb"
@@ -13281,6 +7424,9 @@
             "use_local_location": true
         },
         "thigh.R": {
+            "collections": [
+                "Leg.R (IK)"
+            ],
             "head": {
                 "cube_name": "joint-r-upper-leg",
                 "default_position": [
@@ -13291,115 +7437,19 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "spine",
             "rigify": {
                 "rigify_parameters": {
                     "auto_align_extremity": true,
                     "extra_ik_toe": true,
-                    "fk_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "fk_coll_refs": [
+                        "Leg.R (FK)"
                     ],
                     "ik_local_location": false,
                     "limb_type": "leg",
                     "rotation_axis": "x",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Leg.R (Tweak)"
                     ]
                 },
                 "rigify_type": "limbs.super_limb"
@@ -13420,6 +7470,9 @@
             "use_local_location": true
         },
         "thumb.01.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-1-1",
                 "default_position": [
@@ -13430,77 +7483,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.01.L",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -13521,6 +7509,9 @@
             "use_local_location": true
         },
         "thumb.01.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-1-1",
                 "default_position": [
@@ -13531,77 +7522,12 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "palm.01.R",
             "rigify": {
                 "rigify_parameters": {
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Fingers (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -13622,6 +7548,9 @@
             "use_local_location": true
         },
         "thumb.02.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-1-2",
                 "default_position": [
@@ -13632,40 +7561,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "thumb.01.L",
             "rigify": {},
             "roll": 1.88462,
@@ -13684,6 +7579,9 @@
             "use_local_location": true
         },
         "thumb.02.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-1-2",
                 "default_position": [
@@ -13694,40 +7592,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "thumb.01.R",
             "rigify": {},
             "roll": -1.88462,
@@ -13746,6 +7610,9 @@
             "use_local_location": true
         },
         "thumb.03.L": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-l-finger-1-3",
                 "default_position": [
@@ -13756,40 +7623,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "thumb.02.L",
             "rigify": {},
             "roll": 1.15032,
@@ -13808,6 +7641,9 @@
             "use_local_location": true
         },
         "thumb.03.R": {
+            "collections": [
+                "Fingers"
+            ],
             "head": {
                 "cube_name": "joint-r-finger-1-3",
                 "default_position": [
@@ -13818,40 +7654,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "thumb.02.R",
             "rigify": {},
             "roll": -1.15032,
@@ -13870,6 +7672,9 @@
             "use_local_location": true
         },
         "toe.L": {
+            "collections": [
+                "Leg.L (IK)"
+            ],
             "head": {
                 "cube_name": "joint-l-foot-1",
                 "default_position": [
@@ -13880,40 +7685,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "foot.L",
             "rigify": {},
             "roll": 0.0,
@@ -13933,6 +7704,9 @@
             "use_local_location": true
         },
         "toe.R": {
+            "collections": [
+                "Leg.R (IK)"
+            ],
             "head": {
                 "cube_name": "joint-r-foot-1",
                 "default_position": [
@@ -13943,40 +7717,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "foot.R",
             "rigify": {},
             "roll": 0.0,
@@ -13996,6 +7736,9 @@
             "use_local_location": true
         },
         "toe1-1.L": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-l-toe-1-1",
                 "default_position": [
@@ -14006,78 +7749,13 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe.L",
             "rigify": {
                 "rigify_parameters": {
                     "bbones": 1,
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Toes (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -14099,6 +7777,9 @@
             "use_local_location": true
         },
         "toe1-1.R": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-r-toe-1-1",
                 "default_position": [
@@ -14109,78 +7790,13 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe.R",
             "rigify": {
                 "rigify_parameters": {
                     "bbones": 1,
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Toes (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -14202,6 +7818,9 @@
             "use_local_location": true
         },
         "toe1-2.L": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-l-toe-1-2",
                 "default_position": [
@@ -14212,40 +7831,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe1-1.L",
             "rigify": {},
             "roll": 0.0,
@@ -14265,6 +7850,9 @@
             "use_local_location": true
         },
         "toe1-2.R": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-r-toe-1-2",
                 "default_position": [
@@ -14275,40 +7863,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe1-1.R",
             "rigify": {},
             "roll": 0.0,
@@ -14328,6 +7882,9 @@
             "use_local_location": true
         },
         "toe2-1.L": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-l-toe-2-1",
                 "default_position": [
@@ -14338,78 +7895,13 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe.L",
             "rigify": {
                 "rigify_parameters": {
                     "bbones": 1,
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Toes (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -14431,6 +7923,9 @@
             "use_local_location": true
         },
         "toe2-1.R": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-r-toe-2-1",
                 "default_position": [
@@ -14441,78 +7936,13 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe.R",
             "rigify": {
                 "rigify_parameters": {
                     "bbones": 1,
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Toes (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -14534,6 +7964,9 @@
             "use_local_location": true
         },
         "toe2-2.L": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-l-toe-2-2",
                 "default_position": [
@@ -14544,40 +7977,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe2-1.L",
             "rigify": {},
             "roll": 0.0,
@@ -14597,6 +7996,9 @@
             "use_local_location": true
         },
         "toe2-2.R": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-r-toe-2-2",
                 "default_position": [
@@ -14607,40 +8009,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe2-1.R",
             "rigify": {},
             "roll": 0.0,
@@ -14660,6 +8028,9 @@
             "use_local_location": true
         },
         "toe2-3.L": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-l-toe-2-3",
                 "default_position": [
@@ -14670,40 +8041,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe2-2.L",
             "rigify": {},
             "roll": 0.0,
@@ -14723,6 +8060,9 @@
             "use_local_location": true
         },
         "toe2-3.R": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-r-toe-2-3",
                 "default_position": [
@@ -14733,40 +8073,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe2-2.R",
             "rigify": {},
             "roll": 0.0,
@@ -14786,6 +8092,9 @@
             "use_local_location": true
         },
         "toe3-1.L": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-l-toe-3-1",
                 "default_position": [
@@ -14796,78 +8105,13 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe.L",
             "rigify": {
                 "rigify_parameters": {
                     "bbones": 1,
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Toes (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -14889,6 +8133,9 @@
             "use_local_location": true
         },
         "toe3-1.R": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-r-toe-3-1",
                 "default_position": [
@@ -14899,78 +8146,13 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe.R",
             "rigify": {
                 "rigify_parameters": {
                     "bbones": 1,
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Toes (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -14992,6 +8174,9 @@
             "use_local_location": true
         },
         "toe3-2.L": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-l-toe-3-2",
                 "default_position": [
@@ -15002,40 +8187,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe3-1.L",
             "rigify": {},
             "roll": 0.0,
@@ -15055,6 +8206,9 @@
             "use_local_location": true
         },
         "toe3-2.R": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-r-toe-3-2",
                 "default_position": [
@@ -15065,40 +8219,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe3-1.R",
             "rigify": {},
             "roll": 0.0,
@@ -15118,6 +8238,9 @@
             "use_local_location": true
         },
         "toe3-3.L": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-l-toe-3-3",
                 "default_position": [
@@ -15128,40 +8251,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe3-2.L",
             "rigify": {},
             "roll": 0.0,
@@ -15181,6 +8270,9 @@
             "use_local_location": true
         },
         "toe3-3.R": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-r-toe-3-3",
                 "default_position": [
@@ -15191,40 +8283,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe3-2.R",
             "rigify": {},
             "roll": 0.0,
@@ -15244,6 +8302,9 @@
             "use_local_location": true
         },
         "toe4-1.L": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-l-toe-4-1",
                 "default_position": [
@@ -15254,78 +8315,13 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe.L",
             "rigify": {
                 "rigify_parameters": {
                     "bbones": 1,
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Toes (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -15347,6 +8343,9 @@
             "use_local_location": true
         },
         "toe4-1.R": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-r-toe-4-1",
                 "default_position": [
@@ -15357,78 +8356,13 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe.R",
             "rigify": {
                 "rigify_parameters": {
                     "bbones": 1,
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Toes (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -15450,6 +8384,9 @@
             "use_local_location": true
         },
         "toe4-2.L": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-l-toe-4-2",
                 "default_position": [
@@ -15460,40 +8397,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe4-1.L",
             "rigify": {},
             "roll": 0.0,
@@ -15513,6 +8416,9 @@
             "use_local_location": true
         },
         "toe4-2.R": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-r-toe-4-2",
                 "default_position": [
@@ -15523,40 +8429,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe4-1.R",
             "rigify": {},
             "roll": 0.0,
@@ -15576,6 +8448,9 @@
             "use_local_location": true
         },
         "toe4-3.L": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-l-toe-4-3",
                 "default_position": [
@@ -15586,40 +8461,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe4-2.L",
             "rigify": {},
             "roll": 0.0,
@@ -15639,6 +8480,9 @@
             "use_local_location": true
         },
         "toe4-3.R": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-r-toe-4-3",
                 "default_position": [
@@ -15649,40 +8493,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe4-2.R",
             "rigify": {},
             "roll": 0.0,
@@ -15702,6 +8512,9 @@
             "use_local_location": true
         },
         "toe5-1.L": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-l-toe-5-1",
                 "default_position": [
@@ -15712,78 +8525,13 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe.L",
             "rigify": {
                 "rigify_parameters": {
                     "bbones": 1,
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Toes (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -15805,6 +8553,9 @@
             "use_local_location": true
         },
         "toe5-1.R": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-r-toe-5-1",
                 "default_position": [
@@ -15815,78 +8566,13 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe.R",
             "rigify": {
                 "rigify_parameters": {
                     "bbones": 1,
                     "primary_rotation_axis": "X",
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Toes (Detail)"
                     ]
                 },
                 "rigify_type": "limbs.super_finger"
@@ -15908,6 +8594,9 @@
             "use_local_location": true
         },
         "toe5-2.L": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-l-toe-5-2",
                 "default_position": [
@@ -15918,40 +8607,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe5-1.L",
             "rigify": {},
             "roll": 0.0,
@@ -15971,6 +8626,9 @@
             "use_local_location": true
         },
         "toe5-2.R": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-r-toe-5-2",
                 "default_position": [
@@ -15981,40 +8639,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe5-1.R",
             "rigify": {},
             "roll": 0.0,
@@ -16034,6 +8658,9 @@
             "use_local_location": true
         },
         "toe5-3.L": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-l-toe-5-3",
                 "default_position": [
@@ -16044,40 +8671,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe5-2.L",
             "rigify": {},
             "roll": 0.0,
@@ -16097,6 +8690,9 @@
             "use_local_location": true
         },
         "toe5-3.R": {
+            "collections": [
+                "Toes"
+            ],
             "head": {
                 "cube_name": "joint-r-toe-5-3",
                 "default_position": [
@@ -16107,40 +8703,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "toe5-2.R",
             "rigify": {},
             "roll": 0.0,
@@ -16160,6 +8722,9 @@
             "use_local_location": true
         },
         "tongue": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "cube_name": "joint-tongue-4",
                 "default_position": [
@@ -16170,40 +8735,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "jaw_master",
             "rigify": {
                 "rigify_type": "face.basic_tongue"
@@ -16223,6 +8754,9 @@
             "use_local_location": true
         },
         "tongue.001": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "cube_name": "joint-tongue-3",
                 "default_position": [
@@ -16233,40 +8767,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "tongue",
             "rigify": {},
             "roll": 0.0,
@@ -16284,6 +8784,9 @@
             "use_local_location": true
         },
         "tongue.002": {
+            "collections": [
+                "Face (Secondary)"
+            ],
             "head": {
                 "cube_name": "joint-tongue-2",
                 "default_position": [
@@ -16294,40 +8797,6 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "tongue.001",
             "rigify": {},
             "roll": 0.0,
@@ -16345,6 +8814,9 @@
             "use_local_location": true
         },
         "upper_arm.L": {
+            "collections": [
+                "Arm.L (IK)"
+            ],
             "head": {
                 "cube_name": "joint-l-shoulder",
                 "default_position": [
@@ -16355,111 +8827,15 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "shoulder.L",
             "rigify": {
                 "rigify_parameters": {
-                    "fk_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "fk_coll_refs": [
+                        "Arm.L (FK)"
                     ],
                     "ik_local_location": false,
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Arm.L (Tweak)"
                     ]
                 },
                 "rigify_type": "limbs.super_limb"
@@ -16479,6 +8855,9 @@
             "use_local_location": true
         },
         "upper_arm.R": {
+            "collections": [
+                "Arm.R (IK)"
+            ],
             "head": {
                 "cube_name": "joint-r-shoulder",
                 "default_position": [
@@ -16489,111 +8868,15 @@
                 "strategy": "CUBE"
             },
             "inherit_scale": "FULL",
-            "layers": [
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                true,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false,
-                false
-            ],
             "parent": "shoulder.R",
             "rigify": {
                 "rigify_parameters": {
-                    "fk_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "fk_coll_refs": [
+                        "Arm.R (FK)"
                     ],
                     "ik_local_location": false,
-                    "tweak_layers": [
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        true,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false,
-                        false
+                    "tweak_coll_refs": [
+                        "Arm.R (Tweak)"
                     ]
                 },
                 "rigify_type": "limbs.super_limb"
@@ -16613,6 +8896,32 @@
             "use_local_location": true
         }
     },
+    "collections": [
+        "Face",
+        "Face (Primary)",
+        "Face (Secondary)",
+        "Torso",
+        "Torso (Tweak)",
+        "Fingers",
+        "Fingers (Detail)",
+        "Arm.L (IK)",
+        "Arm.L (FK)",
+        "Arm.L (Tweak)",
+        "Arm.R (IK)",
+        "Arm.R (FK)",
+        "Arm.R (Tweak)",
+        "Leg.L (IK)",
+        "Leg.L (FK)",
+        "Leg.L (Tweak)",
+        "Leg.R (IK)",
+        "Leg.R (FK)",
+        "Leg.R (Tweak)",
+        "Toes",
+        "Toes (Detail)",
+        "Root",
+        "DEF",
+        "MCH"
+    ],
     "extra_bones": [
         "DEF-eye_iris.L",
         "DEF-eye_iris.R",
@@ -16629,6 +8938,176 @@
     ],
     "is_subrig": false,
     "rigify_ui": {
+        "collections": {
+            "Arm.L (FK)": {
+                "color_set_id": 5,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 11,
+                "ui_title": "(FK)"
+            },
+            "Arm.L (IK)": {
+                "color_set_id": 2,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 10,
+                "ui_title": ""
+            },
+            "Arm.L (Tweak)": {
+                "color_set_id": 4,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 12,
+                "ui_title": "(Tweak)"
+            },
+            "Arm.R (FK)": {
+                "color_set_id": 5,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 11,
+                "ui_title": "(FK)"
+            },
+            "Arm.R (IK)": {
+                "color_set_id": 2,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 10,
+                "ui_title": ""
+            },
+            "Arm.R (Tweak)": {
+                "color_set_id": 4,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 12,
+                "ui_title": "(Tweak)"
+            },
+            "DEF": {
+                "color_set_id": 0,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 0,
+                "ui_title": ""
+            },
+            "Face": {
+                "color_set_id": 5,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 1,
+                "ui_title": ""
+            },
+            "Face (Primary)": {
+                "color_set_id": 2,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 2,
+                "ui_title": "(Primary)"
+            },
+            "Face (Secondary)": {
+                "color_set_id": 3,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 2,
+                "ui_title": "(Secondary)"
+            },
+            "Fingers": {
+                "color_set_id": 6,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 7,
+                "ui_title": ""
+            },
+            "Fingers (Detail)": {
+                "color_set_id": 5,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 8,
+                "ui_title": "(Detail)"
+            },
+            "Leg.L (FK)": {
+                "color_set_id": 5,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 15,
+                "ui_title": "(FK)"
+            },
+            "Leg.L (IK)": {
+                "color_set_id": 2,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 14,
+                "ui_title": ""
+            },
+            "Leg.L (Tweak)": {
+                "color_set_id": 4,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 16,
+                "ui_title": "(Tweak)"
+            },
+            "Leg.R (FK)": {
+                "color_set_id": 5,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 15,
+                "ui_title": "(FK)"
+            },
+            "Leg.R (IK)": {
+                "color_set_id": 2,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 14,
+                "ui_title": ""
+            },
+            "Leg.R (Tweak)": {
+                "color_set_id": 4,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 16,
+                "ui_title": "(Tweak)"
+            },
+            "MCH": {
+                "color_set_id": 0,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 0,
+                "ui_title": ""
+            },
+            "Root": {
+                "color_set_id": 1,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 22,
+                "ui_title": ""
+            },
+            "Toes": {
+                "color_set_id": 6,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 18,
+                "ui_title": ""
+            },
+            "Toes (Detail)": {
+                "color_set_id": 5,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 19,
+                "ui_title": "(Detail)"
+            },
+            "Torso": {
+                "color_set_id": 3,
+                "is_visible": true,
+                "sel_set": false,
+                "ui_row": 4,
+                "ui_title": ""
+            },
+            "Torso (Tweak)": {
+                "color_set_id": 4,
+                "is_visible": false,
+                "sel_set": false,
+                "ui_row": 5,
+                "ui_title": "(Tweak)"
+            }
+        },
         "colors": [
             {
                 "name": "Root",
@@ -16679,217 +9158,7 @@
                 ]
             }
         ],
-        "layers": [
-            true,
-            true,
-            true,
-            true,
-            false,
-            true,
-            false,
-            true,
-            false,
-            false,
-            true,
-            false,
-            false,
-            true,
-            false,
-            false,
-            true,
-            false,
-            false,
-            true,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            true,
-            true,
-            false
-        ],
         "rigify_colors_lock": true,
-        "rigify_layers": [
-            {
-                "group": 5,
-                "name": "Face",
-                "row": 1,
-                "selset": false
-            },
-            {
-                "group": 2,
-                "name": "Face (Primary)",
-                "row": 2,
-                "selset": false
-            },
-            {
-                "group": 3,
-                "name": "Face (Secondary)",
-                "row": 2,
-                "selset": false
-            },
-            {
-                "group": 3,
-                "name": "Torso",
-                "row": 3,
-                "selset": false
-            },
-            {
-                "group": 4,
-                "name": "Torso (Tweak)",
-                "row": 4,
-                "selset": false
-            },
-            {
-                "group": 6,
-                "name": "Fingers",
-                "row": 5,
-                "selset": false
-            },
-            {
-                "group": 5,
-                "name": "Fingers (Detail)",
-                "row": 6,
-                "selset": false
-            },
-            {
-                "group": 2,
-                "name": "Arm.L (IK)",
-                "row": 7,
-                "selset": false
-            },
-            {
-                "group": 5,
-                "name": "Arm.L (FK)",
-                "row": 8,
-                "selset": false
-            },
-            {
-                "group": 4,
-                "name": "Arm.L (Tweak)",
-                "row": 9,
-                "selset": false
-            },
-            {
-                "group": 2,
-                "name": "Arm.R (IK)",
-                "row": 7,
-                "selset": false
-            },
-            {
-                "group": 5,
-                "name": "Arm.R (FK)",
-                "row": 8,
-                "selset": false
-            },
-            {
-                "group": 4,
-                "name": "Arm.R (Tweak)",
-                "row": 9,
-                "selset": false
-            },
-            {
-                "group": 2,
-                "name": "Leg.L (IK)",
-                "row": 10,
-                "selset": false
-            },
-            {
-                "group": 5,
-                "name": "Leg.L (FK)",
-                "row": 11,
-                "selset": false
-            },
-            {
-                "group": 4,
-                "name": "Leg.L (Tweak)",
-                "row": 12,
-                "selset": false
-            },
-            {
-                "group": 2,
-                "name": "Leg.R (IK)",
-                "row": 10,
-                "selset": false
-            },
-            {
-                "group": 5,
-                "name": "Leg.R (FK)",
-                "row": 11,
-                "selset": false
-            },
-            {
-                "group": 4,
-                "name": "Leg.R (Tweak)",
-                "row": 12,
-                "selset": false
-            },
-            {
-                "group": 6,
-                "name": "Toes",
-                "row": 13,
-                "selset": false
-            },
-            {
-                "group": 5,
-                "name": "Toes (Detail)",
-                "row": 14,
-                "selset": false
-            },
-            {
-                "group": 0,
-                "name": "",
-                "row": 1,
-                "selset": false
-            },
-            {
-                "group": 0,
-                "name": "",
-                "row": 1,
-                "selset": false
-            },
-            {
-                "group": 0,
-                "name": "",
-                "row": 1,
-                "selset": false
-            },
-            {
-                "group": 0,
-                "name": "",
-                "row": 1,
-                "selset": false
-            },
-            {
-                "group": 0,
-                "name": "",
-                "row": 1,
-                "selset": false
-            },
-            {
-                "group": 0,
-                "name": "",
-                "row": 1,
-                "selset": false
-            },
-            {
-                "group": 0,
-                "name": "",
-                "row": 1,
-                "selset": false
-            },
-            {
-                "group": 1,
-                "name": "Root",
-                "row": 14,
-                "selset": false
-            }
-        ],
         "selection_colors": {
             "active": [
                 0.5490000247955322,
@@ -16904,5 +9173,5 @@
         }
     },
     "scale_factor": 0.10000000149011612,
-    "version": 100
+    "version": 110
 }

--- a/src/mpfb/entities/rig.py
+++ b/src/mpfb/entities/rig.py
@@ -23,7 +23,7 @@ _MEAN_LENGTH_PENALTY = 1.0  # Higher penalizes distant vertex pairs more
 
 CLOSE_MEAN_SEARCH_RADIUS = _MAX_ALLOWED_DIST * 2
 
-CUR_VERSION = 100
+CUR_VERSION = 110
 
 
 class Rig:
@@ -96,6 +96,36 @@ class Rig:
         if version > CUR_VERSION:
             raise ValueError(f"The rig file format version is too high: {version}")
 
+        # Upgrade from layers to collections
+        if version < 110:
+            from mpfb.services.rigifyhelpers.rigifyhelpers import RigifyHelpers
+
+            coll_names = [f"Layer {i+1}" for i in range(32)]
+            coll_used = set()
+
+            # Upgrade Rigify UI data
+            if rigify_ui := self.rig_header.get("rigify_ui"):
+                RigifyHelpers.upgrade_rigify_ui_layers(rigify_ui, coll_names, coll_used)
+            else:
+                coll_names[0] = "Bones"
+
+            # Upgrade bone data
+            for bone_info in self.rig_definition.values():
+                # Layers the bone is assigned to
+                if layers := bone_info.get("layers"):
+                    used = set(i for i, v in enumerate(layers) if v)
+                    bone_info["collections"] = sorted(coll_names[i] for i in used)
+                    coll_used |= used
+                    del bone_info["layers"]
+
+                # Layer references in rigify parameters
+                if rigify := bone_info.get("rigify"):
+                    RigifyHelpers.upgrade_rigify_layer_refs(rigify, coll_names, coll_used)
+
+            # Build the list of used collections
+            if len(coll_used) > 0:
+                self.rig_header["collections"] = [coll_names[i] for i in sorted(coll_used)]
+
         self.rig_header["version"] = CUR_VERSION
         return True
 
@@ -140,6 +170,8 @@ class Rig:
 
         if empty:
             return rig
+
+        rig.rig_header["collections"] = [bcoll.name for bcoll in armature.data.collections]
 
         rig.add_data_bone_info()
 
@@ -196,6 +228,7 @@ class Rig:
 
         bpy.ops.object.mode_set(mode='OBJECT', toggle=False) # To commit removal of bones
 
+        self.create_bone_collections()
         self.create_bones()
         self.update_edit_bone_metadata()
         self.rigify_metadata()
@@ -267,6 +300,18 @@ class Rig:
 
         if matrix:
             bone.roll = bpy.types.Bone.AxisRollFromMatrix(matrix, axis=bone.y_axis)[1]
+
+    def create_bone_collections(self):
+        collections = self.armature_object.data.collections
+
+        if bcoll_names := self.rig_header.get("collections"):
+            for bcoll in list(collections):
+                collections.remove(bcoll)
+
+            for name in bcoll_names:
+                collections.new(name)
+
+        collections.active_index = 0
 
     def create_bones(self):
         """Create the actual bones in the armature object."""
@@ -368,18 +413,12 @@ class Rig:
             bone.use_local_location = bone_info["use_local_location"]
             bone.use_inherit_rotation = bone_info["use_inherit_rotation"]
             bone.inherit_scale = bone_info["inherit_scale"]
-            if "layers" in bone_info:
 
-                # Mask layers to allow deselection
-                i = 0
-                for layer in bone_info["layers"]:
-                    bone.layers[i] = True
-                    i = i + 1
-
-                i = 0
-                for layer in bone_info["layers"]:
-                    bone.layers[i] = layer
-                    i = i + 1
+            if coll_names := bone_info.get("collections"):
+                for name in coll_names:
+                    self.armature_object.data.collections[name].assign(bone)
+            else:
+                self.armature_object.data.collections.active.assign(bone)
 
             if "bendy_bone" in bone_info:
                 for field, val in bone_info["bendy_bone"].items():
@@ -410,10 +449,19 @@ class Rig:
                 for key in rigify["rigify_parameters"].keys():
                     value = rigify["rigify_parameters"][key]
                     _LOG.debug("Will attempt to set bone.parameters.", key)
-                    try:
-                        setattr(bone.rigify_parameters, str(key), value)
-                    except AttributeError:
-                        _LOG.error("Rigify bone parameter not found.", key)
+                    if key.endswith("_coll_refs"):
+                        ref_list = getattr(bone.rigify_parameters, key, None)
+                        if ref_list is not None and hasattr(ref_list, 'add'):
+                            for name in value:
+                                ref = ref_list.add()
+                                ref.name = name
+                        else:
+                            _LOG.error("Rigify bone collection reference list not found.", key)
+                    else:
+                        try:
+                            setattr(bone.rigify_parameters, str(key), value)
+                        except AttributeError:
+                            _LOG.error("Rigify bone parameter not found.", key)
 
         bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
 
@@ -838,9 +886,7 @@ class Rig:
             if bone.bbone_segments > 1:
                 bone_info["bendy_bone"] = self._encode_bbone_info(bone)
 
-            bone_info["layers"] = []
-            for layer in bone.layers:
-                bone_info["layers"].append(layer)
+            bone_info["collections"] = list(sorted(bcoll.name for bcoll in bone.collections))
 
             self.rig_definition[bone.name] = bone_info
 
@@ -924,8 +970,11 @@ class Rig:
                     param_name = str(param)
                     value = getattr(bone.rigify_parameters, param_name)
                     _LOG.debug("param: ", (param_name, value, type(value)))
+
                     if isinstance(value, float) or isinstance(value, int) or isinstance(value, str):
                         rigify["rigify_parameters"][param_name] = value
+                    elif param_name.endswith("_coll_refs"):
+                        rigify["rigify_parameters"][param_name] = [ref.name for ref in value]
                     else:
                         # Assume this is a property array
                         props = []

--- a/src/mpfb/services/humanservice.py
+++ b/src/mpfb/services/humanservice.py
@@ -1174,7 +1174,7 @@ class HumanService:
 
         # Type-specific handling
         if is_rigify:
-            assert len(armature_object.data.rigify_layers) > 0
+            assert len(armature_object.data.rigify_colors) > 0
 
             if hasattr(armature_object.data, 'rigify_rig_basename'):
                 armature_object.data.rigify_rig_basename = "Human.rigify"

--- a/src/mpfb/services/objectservice.py
+++ b/src/mpfb/services/objectservice.py
@@ -428,8 +428,9 @@ class ObjectService:
         if not blender_object or blender_object.type != "ARMATURE" or blender_object.data.get("rig_id"):
             return False
 
-        if blender_object.data.get("rigify_layers") and len(blender_object.data.rigify_layers) > 0\
-                or blender_object.data.get("rigify_target_rig"):
+        if (blender_object.data.get("rigify_target_rig") or
+                blender_object.data.get("rigify_colors") and len(blender_object.data.rigify_colors) > 0 or
+                any(bcoll.get("rigify_ui_row", 0) > 0 for bcoll in blender_object.data.collections)):
             return True
 
         if check_bones:


### PR DESCRIPTION
This updates the json format used for rigs and the code for importing and exporting it to support bone collections and the related new Rigify configuration options. Json files using the old format are automatically upgraded.

The first commit can be cherry picked to master in order to provide a version check with a more readable exception if somebody tries to load a json file using the new format. Or you can merge that commit to master, then merge master into blender4 and apply the second commit there.