### PR TITLE
Add developer panel buttons to import and export individual shape keys as targets.

### DIFF
--- a/src/mpfb/services/targetservice.py
+++ b/src/mpfb/services/targetservice.py
@@ -284,9 +284,18 @@ class TargetService:
         out = ""
         if include_header:
             out = _HEADER
+
+        def fmt(value):
+            s = ('%.3f' % abs(value)).strip('0')
+            if s == '.':
+                return '0'
+            if s[-1] == '.':
+                s = s + '0'
+            return '-' + s if value < 0 else s
+
         for i, x, y, z in shape_key_info["vertices"]:
             # Note XZY order and -Y
-            out = out + "{index} {x} {z} {y}\n".format(index=i, x=round(x, 4), y=round(-y, 4), z=round(z, 4))
+            out = out + "{index} {x} {z} {y}\n".format(index=i, x=fmt(x), y=fmt(-y), z=fmt(z))
         return out
 
     @staticmethod

--- a/src/mpfb/services/targetservice.py
+++ b/src/mpfb/services/targetservice.py
@@ -506,11 +506,7 @@ class TargetService:
             if shape_key.name == target_name:
                 shape_key.value = value
                 if value < 0.0001 and delete_target_on_zero:
-                    # TODO: This simply assumes that the blender_object is also the context active object.
-                    # If this is not the case, this might cause a bit of pain...
-                    shape_key_idx = blender_object.data.shape_keys.key_blocks.find(shape_key.name)
-                    blender_object.active_shape_key_index = shape_key_idx
-                    bpy.ops.object.shape_key_remove()
+                    blender_object.shape_key_remove(shape_key)
 
     @staticmethod
     def bulk_load_targets(blender_object, target_stack, encode_target_names=False):
@@ -918,9 +914,7 @@ class TargetService:
                 _LOG.debug("Checking shape key", (shape_key.name, shape_key.value))
                 if str(shape_key.name).startswith("$md") and shape_key.value < 0.0001:
                     _LOG.debug("Will remove macrodetail target", TargetService.decode_shapekey_name(shape_key.name))
-                    shape_key_idx = basemesh.data.shape_keys.key_blocks.find(shape_key.name)
-                    basemesh.active_shape_key_index = shape_key_idx
-                    bpy.ops.object.shape_key_remove()
+                    basemesh.shape_key_remove(shape_key)
 
         profiler.leave("reapply_macro_details")
 
@@ -981,9 +975,5 @@ class TargetService:
 
         for shape_key in keys.key_blocks:
             if not skip and shape_key.value < cutoff and TargetService.shapekey_is_target(shape_key.name):
-                # TODO: This simply assumes that the blender_object is also the context active object.
-                # If this is not the case, this might cause a bit of pain...
-                shape_key_idx = blender_object.data.shape_keys.key_blocks.find(shape_key.name)
-                blender_object.active_shape_key_index = shape_key_idx
-                bpy.ops.object.shape_key_remove()
+                blender_object.shape_key_remove(shape_key)
             skip = False

--- a/src/mpfb/ui/developer/developerpanel.py
+++ b/src/mpfb/ui/developer/developerpanel.py
@@ -94,6 +94,11 @@ class MPFB_PT_Developer_Panel(bpy.types.Panel):
         box.operator("mpfb.load_weights")
         box.operator("mpfb.save_weights")
 
+    def _targets(self, scene, layout):
+        box = self._create_box(layout, "Load/Save targets")
+        box.operator("mpfb.load_target")
+        box.operator("mpfb.save_target")
+
     def _tests(self, scene, layout):
         box = self._create_box(layout, "Unit tests")
         box.label(text="See README in test dir")
@@ -108,6 +113,7 @@ class MPFB_PT_Developer_Panel(bpy.types.Panel):
         self._nodes(layout)
         self._rig(scene, layout)
         self._weights(scene, layout)
+        self._targets(scene, layout)
         self._tests(scene, layout)
 
 

--- a/src/mpfb/ui/developer/operators/__init__.py
+++ b/src/mpfb/ui/developer/operators/__init__.py
@@ -14,6 +14,8 @@ from .saverig import MPFB_OT_Save_Rig_Operator
 from .loadrig import MPFB_OT_Load_Rig_Operator
 from .saveweights import MPFB_OT_Save_Weights_Operator
 from .loadweights import MPFB_OT_Load_Weights_Operator
+from .savetarget import MPFB_OT_Save_Target_Operator
+from .loadtarget import MPFB_OT_Load_Target_Operator
 from .create_groups import MPFB_OT_Create_Groups_Operator
 from .destroygroups import MPFB_OT_Destroy_Groups_Operator
 from .unittests import MPFB_OT_Unit_Tests_Operator
@@ -32,6 +34,8 @@ __all__ = [
     "MPFB_OT_Load_Rig_Operator",
     "MPFB_OT_Save_Weights_Operator",
     "MPFB_OT_Load_Weights_Operator",
+    "MPFB_OT_Save_Target_Operator",
+    "MPFB_OT_Load_Target_Operator",
     "MPFB_OT_Create_Groups_Operator",
     "MPFB_OT_Destroy_Groups_Operator",
     "MPFB_OT_Unit_Tests_Operator",

--- a/src/mpfb/ui/developer/operators/loadtarget.py
+++ b/src/mpfb/ui/developer/operators/loadtarget.py
@@ -1,0 +1,63 @@
+import os
+import bpy
+
+from bpy_extras.io_utils import ImportHelper
+from bpy.props import StringProperty, CollectionProperty, FloatProperty, BoolProperty
+from mpfb.services.logservice import LogService
+from mpfb.services.objectservice import ObjectService
+from mpfb.services.targetservice import TargetService
+from mpfb import ClassManager
+
+_LOG = LogService.get_logger("developer.operators.loadtarget")
+
+
+class MPFB_OT_Load_Target_Operator(bpy.types.Operator, ImportHelper):
+    """Import one or more targets as shape keys"""
+    bl_idname = "mpfb.load_target"
+    bl_label = "Load targets"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    filter_glob: StringProperty(default='*.target;*.ptarget;*.target.gz;*.ptarget.gz', options={'HIDDEN'})
+    directory: StringProperty(options={'HIDDEN'})
+    files: CollectionProperty(name="File Path", type=bpy.types.OperatorFileListElement)
+
+    weight: FloatProperty(name="Weight", default=1.0, min=0.0, max=1.0,
+                          description="Initial weight to be assigned for the new shape keys")
+    encode: BoolProperty(name="Encode Names", default=False,
+                         description="Encode mpfb macro detail names according to the standard rules")
+
+    @classmethod
+    def poll(cls, context):
+        return ObjectService.object_is_basemesh(context.active_object)
+
+    def draw(self, context):
+        self.layout.operator("file.select_all", text="Select/Deselect All").action = 'TOGGLE'
+        self.layout.prop(self, 'weight')
+        self.layout.prop(self, 'encode')
+
+    def execute(self, context):
+        blender_object = context.active_object
+        filenames = [os.path.join(self.directory, f.name) for f in self.files]
+
+        if not filenames:
+            self.report({'ERROR'}, 'No file is selected for import')
+            return {'CANCELLED'}
+
+        for name in filenames:
+            if not os.path.isfile(name):
+                self.report({'ERROR'}, f'Non-file selected for import: {os.path.basename(name)}')
+                return {'CANCELLED'}
+
+        for name in filenames:
+            if self.encode:
+                shape_name = TargetService.filename_to_shapekey_name(name, macrodetail=None)
+            else:
+                shape_name = TargetService.filename_to_shapekey_name(name)
+
+            TargetService.load_target(blender_object, name, weight=self.weight, name=shape_name)
+
+        self.report({'INFO'}, "Targets were imported as shape keys")
+        return {'FINISHED'}
+
+
+ClassManager.add_class(MPFB_OT_Load_Target_Operator)

--- a/src/mpfb/ui/developer/operators/savetarget.py
+++ b/src/mpfb/ui/developer/operators/savetarget.py
@@ -83,7 +83,7 @@ class MPFB_OT_Save_Target_Operator(bpy.types.Operator, ExportHelper):
         blender_object = context.active_object
         shape_key = self.get_active_key(blender_object)
 
-        info = TargetService.get_shape_key_as_dict(blender_object, shape_key.name)
+        info = TargetService.get_shape_key_as_dict(blender_object, shape_key)
 
         _LOG.dump("Shape key", info)
 

--- a/src/mpfb/ui/developer/operators/savetarget.py
+++ b/src/mpfb/ui/developer/operators/savetarget.py
@@ -1,0 +1,103 @@
+import gzip
+import os
+import re
+
+import bpy
+
+from bpy_extras.io_utils import ExportHelper
+from bpy.props import StringProperty, BoolProperty
+from mpfb.services.logservice import LogService
+from mpfb.services.objectservice import ObjectService
+from mpfb.services.targetservice import TargetService
+from mpfb import ClassManager
+
+_LOG = LogService.get_logger("developer.operators.savetarget")
+
+
+class MPFB_OT_Save_Target_Operator(bpy.types.Operator, ExportHelper):
+    """Write the active shape key as a target file"""
+    bl_idname = "mpfb.save_target"
+    bl_label = "Save target"
+    bl_options = {'REGISTER'}
+
+    filename_ext = '.target'
+
+    filter_glob: StringProperty(default='*.target;*.ptarget;*.target.gz;*.ptarget.gz', options={'HIDDEN'})
+    filepath: StringProperty(name="File Path", description="Filepath used for exporting the file",
+                             maxlen=1024, subtype='FILE_PATH')
+
+    include_header: BoolProperty(name="Include Header", default=False,
+                                 description="Include the boilerplate MakeTarget header")
+
+    @staticmethod
+    def get_active_key(blender_object):
+        index = blender_object.active_shape_key_index
+        key_blocks = blender_object.data.shape_keys.key_blocks
+        if 0 < index < len(key_blocks):
+            return key_blocks[index]
+
+    @classmethod
+    def poll(cls, context):
+        active_object = context.active_object
+
+        if not ObjectService.object_is_basemesh(active_object):
+            return False
+
+        return bool(cls.get_active_key(active_object))
+
+    def invoke(self, context, event):
+        active_object = context.active_object
+        shape_key = self.get_active_key(active_object)
+
+        name = TargetService.decode_shapekey_name(shape_key.name)
+        name = re.sub(r'^macrodetail-', "", name)
+
+        extension = ".target"
+
+        if shape_key.name.startswith("$md-"):
+            extension = ".target.gz"
+
+        self.filepath = bpy.path.clean_name(name, replace="-") + extension
+        return super().invoke(context, event)
+
+    def draw(self, context):
+        self.layout.prop(self, 'include_header')
+
+    def check(self, _context):
+        filepath = self.filepath
+
+        # Override base class to allow all valid extensions
+        if os.path.basename(filepath):
+            if not re.search(r'\.p?target(\.gz)?$', filepath):
+                filepath = bpy.path.ensure_ext(
+                    os.path.splitext(filepath)[0],
+                    self.filename_ext,
+                )
+                if filepath != self.filepath:
+                    self.filepath = filepath
+                    return True
+
+        return False
+
+    def execute(self, context):
+        blender_object = context.active_object
+        shape_key = self.get_active_key(blender_object)
+
+        info = TargetService.get_shape_key_as_dict(blender_object, shape_key.name)
+
+        _LOG.dump("Shape key", info)
+
+        key_string = TargetService.shape_key_info_as_target_string(info, include_header=self.include_header)
+
+        if self.filepath.endswith(".gz"):
+            with gzip.open(self.filepath, "wb") as gzip_file:
+                gzip_file.write(key_string.encode('utf-8'))
+        else:
+            with open(self.filepath, "w") as target_file:
+                target_file.write(key_string)
+
+        self.report({'INFO'}, "Target was saved as " + str(self.filepath))
+        return {'FINISHED'}
+
+
+ClassManager.add_class(MPFB_OT_Save_Target_Operator)


### PR DESCRIPTION
The MakeTarget set of UI tools are clearly aimed at non-technical users in mind, and thus are very restrictive. The most important point is that it expects the user to only work on one target at a time. This is clearly not suitable for comprehensive work on multiple interacting targets, as would be necessary for complex tweaks to targets included in MPFB itself.

This set of commits adds two buttons to the Developer panels that can be used to import or export individual shape keys of the active base mesh object. In case of modifications to existing targets, the export operator can be used to directly save a (modified) shape key that was automatically created by the normal target system.

In addition I try to optimize shape key loading performance by greatly simplifying the used python data structure and related code.