### PR TITLE
Use the new curved B-Bone mapping for rigify lips to follow Rigify master

### DIFF
--- a/src/mpfb/data/rigs/rigify/rig.human.json
+++ b/src/mpfb/data/rigs/rigify/rig.human.json
@@ -5666,6 +5666,9 @@
             "use_local_location": true
         },
         "lip.B.L.001": {
+            "bendy_bone": {
+                "mapping_mode": "CURVED"
+            },
             "collections": [
                 "Face (Secondary)"
             ],
@@ -5766,6 +5769,9 @@
             "use_local_location": true
         },
         "lip.B.R.001": {
+            "bendy_bone": {
+                "mapping_mode": "CURVED"
+            },
             "collections": [
                 "Face (Secondary)"
             ],
@@ -5866,6 +5872,9 @@
             "use_local_location": true
         },
         "lip.T.L.001": {
+            "bendy_bone": {
+                "mapping_mode": "CURVED"
+            },
             "collections": [
                 "Face (Secondary)"
             ],
@@ -5966,6 +5975,9 @@
             "use_local_location": true
         },
         "lip.T.R.001": {
+            "bendy_bone": {
+                "mapping_mode": "CURVED"
+            },
             "collections": [
                 "Face (Secondary)"
             ],

--- a/src/mpfb/data/rigs/rigify/rig.human_toes.json
+++ b/src/mpfb/data/rigs/rigify/rig.human_toes.json
@@ -5666,6 +5666,9 @@
             "use_local_location": true
         },
         "lip.B.L.001": {
+            "bendy_bone": {
+                "mapping_mode": "CURVED"
+            },
             "collections": [
                 "Face (Secondary)"
             ],
@@ -5766,6 +5769,9 @@
             "use_local_location": true
         },
         "lip.B.R.001": {
+            "bendy_bone": {
+                "mapping_mode": "CURVED"
+            },
             "collections": [
                 "Face (Secondary)"
             ],
@@ -5866,6 +5872,9 @@
             "use_local_location": true
         },
         "lip.T.L.001": {
+            "bendy_bone": {
+                "mapping_mode": "CURVED"
+            },
             "collections": [
                 "Face (Secondary)"
             ],
@@ -5966,6 +5975,9 @@
             "use_local_location": true
         },
         "lip.T.R.001": {
+            "bendy_bone": {
+                "mapping_mode": "CURVED"
+            },
             "collections": [
                 "Face (Secondary)"
             ],

--- a/src/mpfb/entities/rig.py
+++ b/src/mpfb/entities/rig.py
@@ -883,8 +883,8 @@ class Rig:
             bone_info["use_inherit_rotation"] = bone.use_inherit_rotation
             bone_info["inherit_scale"] = bone.inherit_scale
 
-            if bone.bbone_segments > 1:
-                bone_info["bendy_bone"] = self._encode_bbone_info(bone)
+            if bbone_info := self._encode_bbone_info(bone):
+                bone_info["bendy_bone"] = bbone_info
 
             bone_info["collections"] = list(sorted(bcoll.name for bcoll in bone.collections))
 
@@ -921,6 +921,7 @@ class Rig:
     def _encode_bbone_info(self, bone):
         defaults = {
             "segments": 1,
+            "mapping_mode": "STRAIGHT",
             "custom_handle_start": None, "custom_handle_end": None,
             "handle_type_start": "AUTO", "handle_type_end": "AUTO",
             "handle_use_ease_start": False, "handle_use_ease_end": False,


### PR DESCRIPTION
This is a new 4.0 feature that improves deformation around the lip corners.

I also changed the rig saving code to store any b-bone properties that are changed from their defaults,
even if the segment count is 1, because Rigify generation may assign a segment count later while preserving
other settings, so the count value in the metarig doesn't matter in those cases.

https://projects.blender.org/blender/blender/pulls/110758
https://projects.blender.org/blender/blender-addons/commit/ce6775b50d4e7231dc8c72715cdf49f3d3b83707