### PR TITLE
Cache measure target values

### DIFF
--- a/src/mpfb/services/targetservice.py
+++ b/src/mpfb/services/targetservice.py
@@ -1,6 +1,6 @@
 """Module for managing targets and shape keys."""
 
-import os, gzip, bpy, json, random, re
+import os, gzip, bpy, json, random, re, hashlib, time
 from itertools import count
 from functools import lru_cache
 from math import dist, fabs
@@ -1131,7 +1131,7 @@ class TargetService:
         _min_value = -1.0
         _max_value = 1.0
 
-        # Find the maximum and minimum real world values 
+        # Find the maximum and minimum real world values
         # Not being used anywhere here. However helped identify issues
         # with the way how extremes are being calculated
         target_paths = [
@@ -1209,3 +1209,14 @@ class TargetService:
 
         base_name = measure_target_base_name[:-5] if measure_target_base_name.endswith(('-incr', '-decr')) else measure_target_base_name
         return TargetService.get_current_measure(basemesh, base_name, metric)
+
+    @staticmethod
+    def get_target_stack_fingerprint(basemesh):
+        """Returns a md5sum hash of the target stack"""
+        before = time.time()
+        target_stack = TargetService.get_target_stack(basemesh)
+        target_stack_json = json.dumps(target_stack, sort_keys=True)
+        target_stack_md5 = hashlib.md5(target_stack_json.encode('utf-8')).hexdigest()
+        after = time.time()
+        _LOG.debug("Obj, Fingerprint, time", (basemesh, target_stack_md5, 1000.0 * (after - before)))
+        return target_stack_md5

--- a/test/tests/01_services/targetservice_test.py
+++ b/test/tests/01_services/targetservice_test.py
@@ -4,6 +4,7 @@ from mpfb.services.objectservice import ObjectService
 from mpfb.services.humanservice import HumanService
 from mpfb.services.locationservice import LocationService
 from mpfb.services.targetservice import TargetService
+from mpfb.entities.objectproperties import HumanObjectProperties
 
 def test_targetservice_exists():
     """TargetService"""
@@ -57,3 +58,24 @@ def test_prune_shapekeys():
     TargetService.prune_shapekeys(obj)
 
     assert "yadayada" in obj.data.shape_keys.key_blocks
+
+def test_target_fingerprinting():
+    """TargetService.get_target_stack_fingerprint()"""
+    obj = HumanService.create_human()
+    assert obj is not None
+
+    fingerprint_before = TargetService.get_target_stack_fingerprint(obj)
+    assert fingerprint_before is not None
+
+    TargetService.reapply_macro_details(obj, remove_zero_weight_targets=True)
+    fingerprint_inbetween = TargetService.get_target_stack_fingerprint(obj)
+    assert fingerprint_inbetween is not None
+    assert fingerprint_before == fingerprint_inbetween
+
+    HumanObjectProperties.set_value("weight", 0.75, entity_reference=obj)
+    TargetService.reapply_macro_details(obj, remove_zero_weight_targets=True)
+
+    fingerprint_after = TargetService.get_target_stack_fingerprint(obj)
+    assert fingerprint_after is not None
+    assert fingerprint_before != fingerprint_after
+


### PR DESCRIPTION
@maryam-fatima: 

This is a suggestion for a strategy for caching measure target values so that the UI doesn't become affected. I didn't want to push it directly to the blender4_measure branch in case you had done additional changes. 
