### PR TITLE
Fix an issue with OpenPose exports using Perspective projection

### DIFF
--- a/src/mpfb/ui/ai/operators/saveopenpose.py
+++ b/src/mpfb/ui/ai/operators/saveopenpose.py
@@ -36,7 +36,7 @@ class MPFB_OT_Save_Openpose_Operator(bpy.types.Operator, ExportHelper):
         # Due to limitations in world_to_camera_view(), this ends up distorted. A world coordinate is
         # not matched to what the camera actually sees in an exact manner, as the method does not take
         # all camera settings into account. The final results are unpredictable and often depressing.
-        cam_coord = world_to_camera_view(scene, camera, keypoint)
+        cam_coord = world_to_camera_view(scene, camera, Vector(keypoint))
         _LOG.debug("Cam projection", (keypoint, cam_coord))
         return [cam_coord[0] * resx, (1.0 - cam_coord[1]) * resy]
 


### PR DESCRIPTION
When trying to export an OpenPose JSON using Perspective projection on Blender 4.3.0 running on Arch Linux, I got the following error:

```
Python: Traceback (most recent call last):
  File "/home//.config/blender/4.3/extensions/user_default/mpfb/ui/ai/operators/saveopenpose.py", line 208, in execute
    coord_mapping = self._get_keypoints_2d(armature_object, bm, context.scene, camera, resx, resy, bodymapper)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home//.config/blender/4.3/extensions/user_default/mpfb/ui/ai/operators/saveopenpose.py", line 100, in _get_keypoints_2d
    remapped = self._as_camera_coordinate(scene, camera, resx, resy, keypoint)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home//.config/blender/4.3/extensions/user_default/mpfb/ui/ai/operators/saveopenpose.py", line 39, in _as_camera_coordinate
    cam_coord = world_to_camera_view(scene, camera, keypoint)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/blender/4.3/scripts/modules/bpy_extras/object_utils.py", line 249, in world_to_camera_view
    co_local = obj.matrix_world.normalized().inverted() @ coord
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
TypeError: Matrix multiplication: not supported between 'Matrix' and 'list' types
```

The steps I took were:

1. Create a new human from scratch
2. Add the "Default" rig
3. Under Operations > OpenPose, choose "Perspective projection", click "Save openpose", and try saving the output file

This PR fixes the issue, and I have checked to make sure the exported JSON is correct.