### PR TITLE
Base for card generation properties

### DIFF
--- a/src/mpfb/ui/haireditorpanel/haireditorpanel.py
+++ b/src/mpfb/ui/haireditorpanel/haireditorpanel.py
@@ -63,6 +63,13 @@ class MPFB_PT_Hair_Editor_Panel(Abstract_Panel):
                 toggle_prop = f"{asset_name}_hair_asset_open"
                 HAIR_PROPERTIES.draw_properties(basemesh, col, [toggle_prop])
                 is_open = HAIR_PROPERTIES.get_value(toggle_prop, entity_reference=basemesh)
+
+                cards_gen_prop = f"{asset_name}_hair_cards_are_generated"
+                cards_are_generated = HAIR_PROPERTIES.get_value(cards_gen_prop, entity_reference=basemesh)
+
+                cards_baked_prop = f"{asset_name}_hair_cards_are_baked"
+                cards_are_baked = HAIR_PROPERTIES.get_value(cards_baked_prop, entity_reference=basemesh)
+
                 if is_open:
                     box = col.box()
                     #box.label(text=f"{asset_name}")
@@ -73,6 +80,13 @@ class MPFB_PT_Hair_Editor_Panel(Abstract_Panel):
                     for prop in DYNAMIC_HAIR_MATERIAL_PROPS_DEFINITIONS.keys():
                         propname = f"{HAIR_PROPERTIES.dynamic_prefix}{asset_name}_{prop}"
                         box.prop(basemesh, propname, text=prop)
+                    
+                    if not cards_are_generated:
+                        # generate cards button
+                        pass
+                    elif(cards_are_generated and not cards_are_baked):
+                        # properties and bake button
+                        pass
 
         # TODO: Port cards, delete etc
 
@@ -131,6 +145,12 @@ class MPFB_PT_Hair_Editor_Panel(Abstract_Panel):
                 FUR_PROPERTIES.draw_properties(basemesh, col, [toggle_prop])
                 is_open = FUR_PROPERTIES.get_value(toggle_prop, entity_reference=basemesh)
 
+                cards_gen_prop = f"{asset_name}_fur_cards_are_generated"
+                cards_are_generated = FUR_PROPERTIES.get_value(cards_gen_prop, entity_reference=basemesh)
+
+                cards_baked_prop = f"{asset_name}_fur_cards_are_baked"
+                cards_are_baked = FUR_PROPERTIES.get_value(cards_baked_prop, entity_reference=basemesh)
+
                 if is_open:
                     box = col.box()
                     #box.label(text=f"{asset_name}")
@@ -141,6 +161,15 @@ class MPFB_PT_Hair_Editor_Panel(Abstract_Panel):
                     for prop in DYNAMIC_FUR_MATERIAL_PROPS_DEFINITIONS.keys():
                         propname = f"{FUR_PROPERTIES.dynamic_prefix}{asset_name}_{prop}"
                         box.prop(basemesh, propname, text=prop)
+                    
+                    if not cards_are_generated:
+                        # generate cards button
+                        pass
+                    elif(cards_are_generated and not cards_are_baked):
+                        # properties and bake button
+                        pass
+
+
 
 # TODO: fur card and delete stuff
 #===============================================================================

--- a/src/mpfb/ui/haireditorpanel/operators/apply_fur_operator.py
+++ b/src/mpfb/ui/haireditorpanel/operators/apply_fur_operator.py
@@ -172,6 +172,30 @@ class MPFB_OT_ApplyFur_Operator(bpy.types.Operator):
 
         FUR_PROPERTIES.set_value_dynamic(propname, False, propdef, entity_reference=basemesh)
 
+        propname = f"{prop_prefix}fur_cards_are_generated"
+        propdef = {
+            "name": propname,
+            "type": "boolean",
+            "label": f"{self.hair_asset}",
+            "description": "Toggle visibility of card placement and baking properties",
+            "default": False,
+            "subtype": "panel_toggle"
+            }
+
+        FUR_PROPERTIES.set_value_dynamic(propname, False, propdef, entity_reference=basemesh)
+
+        propname = f"{prop_prefix}fur_cards_are_baked"
+        propdef = {
+            "name": propname,
+            "type": "boolean",
+            "label": f"{self.hair_asset}",
+            "description": "Hides options for card placement and baking",
+            "default": False,
+            "subtype": "panel_toggle"
+            }
+
+        FUR_PROPERTIES.set_value_dynamic(propname, False, propdef, entity_reference=basemesh)
+
         ObjectService.deselect_and_deactivate_all()
         ObjectService.activate_blender_object(basemesh)
 

--- a/src/mpfb/ui/haireditorpanel/operators/apply_hair_operator.py
+++ b/src/mpfb/ui/haireditorpanel/operators/apply_hair_operator.py
@@ -160,6 +160,30 @@ class MPFB_OT_ApplyHair_Operator(bpy.types.Operator):
 
         HAIR_PROPERTIES.set_value_dynamic(propname, False, propdef, entity_reference=basemesh)
 
+        propname = f"{prop_prefix}hair_cards_are_generated"
+        propdef = {
+            "name": propname,
+            "type": "boolean",
+            "label": f"{self.hair_asset}",
+            "description": "Toggle visibility of card placement and baking properties",
+            "default": False,
+            "subtype": "panel_toggle"
+            }
+
+        HAIR_PROPERTIES.set_value_dynamic(propname, False, propdef, entity_reference=basemesh)
+
+        propname = f"{prop_prefix}hair_cards_are_baked"
+        propdef = {
+            "name": propname,
+            "type": "boolean",
+            "label": f"{self.hair_asset}",
+            "description": "Hides options for card placement and baking",
+            "default": False,
+            "subtype": "panel_toggle"
+            }
+
+        HAIR_PROPERTIES.set_value_dynamic(propname, False, propdef, entity_reference=basemesh)
+
         ObjectService.deselect_and_deactivate_all()
         ObjectService.activate_blender_object(basemesh)
 


### PR DESCRIPTION
In apply_hair/fur_operator.py are added properties indicating whether cards were alredy generated/baked

UI in haireditorpanel.py has prepared branches for separate stages of generating and baking cards.


