### PR TITLE
Implement check for same scale, for issue #263

### DIFF
--- a/src/mpfb/services/clothesservice.py
+++ b/src/mpfb/services/clothesservice.py
@@ -634,6 +634,7 @@ class ClothesService:
                 - all_verts_belong_to_faces (bool): Whether all vertices belong to at least one face.
                 - all_checks_ok (bool): Whether all validation checks passed.
                 - clothes_groups_exist_on_basemesh (bool): Whether the clothes groups exist on the basemesh.
+                - objs_same_scale: Whether the clothes object and basemesh have the same scale.
                 - warnings (list): A list of warnings encountered during validation.
         """
 
@@ -646,6 +647,7 @@ class ClothesService:
             "all_verts_belong_to_faces": True,
             "all_checks_ok": False,
             "clothes_groups_exist_on_basemesh": True,
+            "objs_same_scale": True,
             "warnings": []
             }
 
@@ -680,9 +682,17 @@ class ClothesService:
             else:
                 paired_groups.append(group_name)
 
+        # Check if the clothes object and basemesh have the same scale
+        for axis in range(3):
+            clothes_scale = mesh_object.scale[axis]
+            basemesh_scale = basemesh.scale[axis]
+            if abs(clothes_scale - basemesh_scale) > 0.0001:
+                report["objs_same_scale"] = False
+                report["warnings"].append(f"Basemesh and clothes scale are different on axis {axis}")
+
         all_ok = report["is_valid_object"] and report["has_any_vertices"] and report["has_any_vgroups"]
         all_ok = all_ok and report["all_verts_have_max_one_vgroup"] and report["all_verts_have_min_one_vgroup"] and report["all_verts_belong_to_faces"]
-        all_ok = all_ok and report["clothes_groups_exist_on_basemesh"]
+        all_ok = all_ok and report["clothes_groups_exist_on_basemesh"] and report["objs_same_scale"]
         report["all_checks_ok"] = all_ok
 
         cache_dir = LocationService.get_user_cache("basemesh_xref")

--- a/src/mpfb/ui/makeclothes/makeclothespanel.py
+++ b/src/mpfb/ui/makeclothes/makeclothespanel.py
@@ -210,7 +210,7 @@ class MPFB_PT_MakeClothes_Panel(Abstract_Panel):
         else:
             check = CLOTHES_CHECKS[uuid_value]
             _LOG.debug("Valid clothes check", (uuid_value, check))
-            for check_label in ['is_valid_object', 'has_any_vertices', 'has_any_vgroups', 'all_verts_have_max_one_vgroup', 'all_verts_have_min_one_vgroup', 'all_verts_belong_to_faces', 'clothes_groups_exist_on_basemesh', 'all_checks_ok']:
+            for check_label in ['is_valid_object', 'has_any_vertices', 'has_any_vgroups', 'all_verts_have_max_one_vgroup', 'all_verts_have_min_one_vgroup', 'all_verts_belong_to_faces', 'clothes_groups_exist_on_basemesh', 'objs_same_scale', 'all_checks_ok']:
                 name = str(check_label).replace("_", " ").capitalize()
                 value = str(check[check_label]).upper()
                 box.label(text=name + ": " + value)


### PR DESCRIPTION
Adds a check for scale differences between the clothes object and the basemesh. The result of the check is visible in the clothes check section of the makeclothes panel.

This solves the problem with clothes production failing on scale despite all checks saying everything is ok.
