### PR TITLE
hair/fur asset delete button added

### DIFF
--- a/src/mpfb/ui/haireditorpanel/haireditorpanel.py
+++ b/src/mpfb/ui/haireditorpanel/haireditorpanel.py
@@ -61,7 +61,6 @@ class MPFB_PT_Hair_Editor_Panel(Abstract_Panel):
             if str(key).endswith("_hair_asset_open"):
                 asset_name = str(key).replace("_hair_asset_open", "")
                 toggle_prop = f"{asset_name}_hair_asset_open"
-                HAIR_PROPERTIES.draw_properties(basemesh, col, [toggle_prop])
                 is_open = HAIR_PROPERTIES.get_value(toggle_prop, entity_reference=basemesh)
 
                 cards_gen_prop = f"{asset_name}_hair_cards_are_generated"
@@ -70,7 +69,14 @@ class MPFB_PT_Hair_Editor_Panel(Abstract_Panel):
                 cards_baked_prop = f"{asset_name}_hair_cards_are_baked"
                 cards_are_baked = HAIR_PROPERTIES.get_value(cards_baked_prop, entity_reference=basemesh)
 
-                if is_open:
+                # dont show the asset in UI if it has been deleted
+                hair_asset = bpy.data.objects.get(asset_name)
+                asset_exists = (hair_asset and hair_asset.parent == basemesh)
+
+                if asset_exists:
+                    HAIR_PROPERTIES.draw_properties(basemesh, col, [toggle_prop])
+                
+                if asset_exists and is_open:
                     box = col.box()
                     #box.label(text=f"{asset_name}")
 
@@ -87,6 +93,9 @@ class MPFB_PT_Hair_Editor_Panel(Abstract_Panel):
                     elif(cards_are_generated and not cards_are_baked):
                         # properties and bake button
                         pass
+                    
+                    op_del = box.operator("mpfb.delete_hair_operator", text="Delete hair")
+                    op_del.hair_asset =asset_name
 
         # TODO: Port cards, delete etc
 
@@ -142,8 +151,8 @@ class MPFB_PT_Hair_Editor_Panel(Abstract_Panel):
                 asset_name = str(key).replace("_fur_asset_open", "")
                 toggle_prop = f"{asset_name}_fur_asset_open"
 
-                FUR_PROPERTIES.draw_properties(basemesh, col, [toggle_prop])
-                is_open = FUR_PROPERTIES.get_value(toggle_prop, entity_reference=basemesh)
+
+                is_open = FUR_PROPERTIES.get_value(toggle_prop, entity_reference=basemesh) 
 
                 cards_gen_prop = f"{asset_name}_fur_cards_are_generated"
                 cards_are_generated = FUR_PROPERTIES.get_value(cards_gen_prop, entity_reference=basemesh)
@@ -151,7 +160,13 @@ class MPFB_PT_Hair_Editor_Panel(Abstract_Panel):
                 cards_baked_prop = f"{asset_name}_fur_cards_are_baked"
                 cards_are_baked = FUR_PROPERTIES.get_value(cards_baked_prop, entity_reference=basemesh)
 
-                if is_open:
+                # dont show the asset in UI if it has been deleted
+                hair_asset = bpy.data.objects.get(asset_name)
+                asset_exists = (hair_asset and hair_asset.parent == basemesh)
+
+                if asset_exists:
+                    FUR_PROPERTIES.draw_properties(basemesh, col, [toggle_prop])
+                if asset_exists and is_open:
                     box = col.box()
                     #box.label(text=f"{asset_name}")
 
@@ -168,7 +183,9 @@ class MPFB_PT_Hair_Editor_Panel(Abstract_Panel):
                     elif(cards_are_generated and not cards_are_baked):
                         # properties and bake button
                         pass
-
+                
+                    op_del = box.operator("mpfb.delete_hair_operator", text="Delete hair")
+                    op_del.hair_asset =asset_name
 
 
 # TODO: fur card and delete stuff

--- a/src/mpfb/ui/haireditorpanel/operators/delete_hair_operator.py
+++ b/src/mpfb/ui/haireditorpanel/operators/delete_hair_operator.py
@@ -26,11 +26,11 @@ class MPFB_OT_DeleteHair_Operator(bpy.types.Operator):
         scene = context.scene
 
         self.report({'INFO'}, ("Deleting hair asset..."))
-
+    
         # Get Human object
         human_obj = context.object
-        if not human_obj or human_obj.name != 'Human':
-            self.report({'ERROR'}, "Object 'Human' must be active")
+        if not human_obj:
+            self.report({'ERROR'}, "Human object must be active")
             return {'CANCELLED'}
 
         # Get hair and eventual card assets
@@ -67,41 +67,6 @@ class MPFB_OT_DeleteHair_Operator(bpy.types.Operator):
             return {'CANCELLED'}
         if card_obj:
             bpy.data.objects.remove(card_obj, do_unlink=True)
-
-        # Force _cards_generated and _cards_baked to be false
-        prop_name = f"{self.hair_asset}_cards_generated"
-        if hasattr(scene, prop_name):
-            setattr(scene, prop_name, False)
-        prop_name = f"{self.hair_asset}_cards_baked"
-        if hasattr(scene, prop_name):
-            setattr(scene, prop_name, False)
-
-
-        # Remove assetes properties
-        prop_prefix = f"{self.hair_asset}_"
-        for name in [
-            "length", "density", "thickness", "frizz", "roll", "roll_radius",
-            "roll_length", "clump", "clump_distance", "clump_shape", "clump_tip_spread",
-            "noise", "noise_distance", "noise_scale", "noise_shape",
-            "curl", "curl_guide_distance", "curl_radius", "curl_frequency",
-            "holes", "holes_scale",
-            "fur_asset_open", "hair_asset_open",
-            "_cards_scale", "_cards_density", "_cards_placement",
-            "_cards_resolution", "_cards_samples", "_cards_glossy", "_cards_generated", "_cards_texture_dst", "_cards_baked"
-        ]:
-            prop_id = f"{prop_prefix}{name}"
-            if hasattr(scene.__class__, prop_id):
-                delattr(scene.__class__, prop_id)
-
-        # Remove material properties
-        mat_name = f"{self.hair_asset}"
-        material_props = [
-            "color1", "color2", "coror_noise_scale", "darken_root", "root_color_length"
-        ]
-        for name in material_props:
-            prop_id = f"{mat_name}_{name}"
-            if hasattr(scene.__class__, prop_id):
-                delattr(scene.__class__, prop_id)
 
         # Delete material
         material = bpy.data.materials.get(self.hair_asset)


### PR DESCRIPTION
- delete_hair_operator cleaned from dead code and added to haireditorpanel as delete button

- Added check in the haireditorpanel if the hair asset from properties actually exists. If not, UI drawer with morphs for this asset will not be drawn


