### PR TITLE
Fix T-Pose for mixamo unity

### DIFF
--- a/src/mpfb/data/poses/mixamo_unity_fk/t-pose.json
+++ b/src/mpfb/data/poses/mixamo_unity_fk/t-pose.json
@@ -55,5 +55,5 @@
     "has_ik_bones": false,
     "original_shoulder_width": 0,
     "original_spine_length": 0,
-    "skeleton_type": "mixamo_extended"
+    "skeleton_type": "mixamo_unity"
 }


### PR DESCRIPTION
# Description

Minor correction: T-pose still has its old name (`mixamo_extended` instead of `mixamo_unity`).