### PR TITLE
Ensure compatibility with blender 4.2.x and 5.0

### DIFF
--- a/src/mpfb/__init__.py
+++ b/src/mpfb/__init__.py
@@ -35,7 +35,7 @@ It also exposes a few important functions and objects:
 fake_bl_info = {  # pylint: disable=C0103
     "name": "mpfb",
     "author": "Joel Palmius",
-    "version": (2, 0, 11),
+    "version": (2, 0, 12),
     "blender": (4, 2, 0),
     "location": "View3D > Properties > MPFB",
     "description": "Free and open source human character editor",

--- a/src/mpfb/blender_manifest.toml
+++ b/src/mpfb/blender_manifest.toml
@@ -1,6 +1,6 @@
 schema_version = "1.0.0"
 id = "mpfb"
-version = "2.0.11"
+version = "2.0.12"
 name = "MPFB"
 tagline = "Human character generator and editor"
 maintainer = "Joel Palmius"

--- a/src/mpfb/data/node_trees/enhanced_skin.json
+++ b/src/mpfb/data/node_trees/enhanced_skin.json
@@ -261,23 +261,23 @@
                     "from_node": "SSSRadiusRed",
                     "from_socket": "Value",
                     "to_node": "Combine RGB",
-                    "to_socket": "R"
+                    "to_socket": "X"
                 },
                 {
                     "from_node": "SSSRadiusGreen",
                     "from_socket": "Value",
                     "to_node": "Combine RGB",
-                    "to_socket": "G"
+                    "to_socket": "Y"
                 },
                 {
                     "from_node": "SSSRadiusBlue",
                     "from_socket": "Value",
                     "to_node": "Combine RGB",
-                    "to_socket": "B"
+                    "to_socket": "Z"
                 },
                 {
                     "from_node": "Combine RGB",
-                    "from_socket": "Image",
+                    "from_socket": "Vector",
                     "to_node": "Principled BSDF",
                     "to_socket": "Subsurface Radius"
                 },
@@ -349,7 +349,7 @@
                         -175.0984344482422
                     ],
                     "name": "Combine RGB",
-                    "type": "ShaderNodeCombineRGB",
+                    "type": "ShaderNodeCombineXYZ",
                     "values": {}
                 },
                 "Group Input": {

--- a/src/mpfb/entities/nodemodel/v2/primitives/__init__.py
+++ b/src/mpfb/entities/nodemodel/v2/primitives/__init__.py
@@ -23,8 +23,6 @@ from .nodewrappershadernodebump import snBump
 from .nodewrappershadernodecameradata import snCameraData
 from .nodewrappershadernodeclamp import snClamp
 from .nodewrappershadernodecombinecolor import snCombineColor
-from .nodewrappershadernodecombinehsv import snCombineHSV
-from .nodewrappershadernodecombinergb import snCombineRGB
 from .nodewrappershadernodecombinexyz import snCombineXYZ
 from .nodewrappershadernodedisplacement import snDisplacement
 from .nodewrappershadernodeeeveespecular import snEeveeSpecular
@@ -62,8 +60,6 @@ from .nodewrappershadernodergbcurve import snRGBCurve
 from .nodewrappershadernodergbtobw import snRGBToBW
 from .nodewrappershadernodescript import snScript
 from .nodewrappershadernodeseparatecolor import snSeparateColor
-from .nodewrappershadernodeseparatehsv import snSeparateHSV
-from .nodewrappershadernodeseparatergb import snSeparateRGB
 from .nodewrappershadernodeseparatexyz import snSeparateXYZ
 from .nodewrappershadernodeshadertorgb import snShaderToRGB
 from .nodewrappershadernodesqueeze import snSqueeze
@@ -80,7 +76,6 @@ from .nodewrappershadernodetexmagic import snTexMagic
 if not SystemService.is_blender_version_at_least(version=[4,1,0]):
     from .nodewrappershadernodetexmusgrave import snTexMusgrave
 from .nodewrappershadernodetexnoise import snTexNoise
-from .nodewrappershadernodetexpointdensity import snTexPointDensity
 from .nodewrappershadernodetexsky import snTexSky
 from .nodewrappershadernodetexvoronoi import snTexVoronoi
 from .nodewrappershadernodetexwave import snTexWave
@@ -125,8 +120,6 @@ PRIMITIVE_NODE_WRAPPERS["ShaderNodeBump"] = snBump
 PRIMITIVE_NODE_WRAPPERS["ShaderNodeCameraData"] = snCameraData
 PRIMITIVE_NODE_WRAPPERS["ShaderNodeClamp"] = snClamp
 PRIMITIVE_NODE_WRAPPERS["ShaderNodeCombineColor"] = snCombineColor
-PRIMITIVE_NODE_WRAPPERS["ShaderNodeCombineHSV"] = snCombineHSV
-PRIMITIVE_NODE_WRAPPERS["ShaderNodeCombineRGB"] = snCombineRGB
 PRIMITIVE_NODE_WRAPPERS["ShaderNodeCombineXYZ"] = snCombineXYZ
 PRIMITIVE_NODE_WRAPPERS["ShaderNodeDisplacement"] = snDisplacement
 PRIMITIVE_NODE_WRAPPERS["ShaderNodeEeveeSpecular"] = snEeveeSpecular
@@ -164,8 +157,6 @@ PRIMITIVE_NODE_WRAPPERS["ShaderNodeRGBCurve"] = snRGBCurve
 PRIMITIVE_NODE_WRAPPERS["ShaderNodeRGBToBW"] = snRGBToBW
 PRIMITIVE_NODE_WRAPPERS["ShaderNodeScript"] = snScript
 PRIMITIVE_NODE_WRAPPERS["ShaderNodeSeparateColor"] = snSeparateColor
-PRIMITIVE_NODE_WRAPPERS["ShaderNodeSeparateHSV"] = snSeparateHSV
-PRIMITIVE_NODE_WRAPPERS["ShaderNodeSeparateRGB"] = snSeparateRGB
 PRIMITIVE_NODE_WRAPPERS["ShaderNodeSeparateXYZ"] = snSeparateXYZ
 PRIMITIVE_NODE_WRAPPERS["ShaderNodeShaderToRGB"] = snShaderToRGB
 PRIMITIVE_NODE_WRAPPERS["ShaderNodeSqueeze"] = snSqueeze
@@ -184,7 +175,6 @@ if not SystemService.is_blender_version_at_least(version=[4,1,0]):
     PRIMITIVE_NODE_WRAPPERS["ShaderNodeTexMusgrave"] = snTexMusgrave
 
 PRIMITIVE_NODE_WRAPPERS["ShaderNodeTexNoise"] = snTexNoise
-PRIMITIVE_NODE_WRAPPERS["ShaderNodeTexPointDensity"] = snTexPointDensity
 PRIMITIVE_NODE_WRAPPERS["ShaderNodeTexSky"] = snTexSky
 PRIMITIVE_NODE_WRAPPERS["ShaderNodeTexVoronoi"] = snTexVoronoi
 PRIMITIVE_NODE_WRAPPERS["ShaderNodeTexWave"] = snTexWave
@@ -231,8 +221,6 @@ __all__ = [
     "snCameraData",
     "snClamp",
     "snCombineColor",
-    "snCombineHSV",
-    "snCombineRGB",
     "snCombineXYZ",
     "snDisplacement",
     "snEeveeSpecular",
@@ -270,8 +258,6 @@ __all__ = [
     "snRGBToBW",
     "snScript",
     "snSeparateColor",
-    "snSeparateHSV",
-    "snSeparateRGB",
     "snSeparateXYZ",
     "snShaderToRGB",
     "snSqueeze",
@@ -286,7 +272,6 @@ __all__ = [
     "snTexImage",
     "snTexMagic",
     "snTexNoise",
-    "snTexPointDensity",
     "snTexSky",
     "snTexVoronoi",
     "snTexWave",

--- a/src/mpfb/services/systemservice.py
+++ b/src/mpfb/services/systemservice.py
@@ -4,7 +4,7 @@ import os, sys, subprocess, bpy, addon_utils, re
 from .logservice import LogService
 _LOG = LogService.get_logger("services.systemservice")
 
-LOWEST_FUNCTIONAL_BLENDER_VERSION = (4, 3, 0)
+LOWEST_FUNCTIONAL_BLENDER_VERSION = (4, 2, 0)
 
 
 class SystemService:

--- a/test/tests/ddd_entities/nodemodel_v2_primitives_test.py
+++ b/test/tests/ddd_entities/nodemodel_v2_primitives_test.py
@@ -27,8 +27,6 @@ snBump = dynamic_import("mpfb.entities.nodemodel.v2", "snBump")
 snCameraData = dynamic_import("mpfb.entities.nodemodel.v2", "snCameraData")
 snClamp = dynamic_import("mpfb.entities.nodemodel.v2", "snClamp")
 snCombineColor = dynamic_import("mpfb.entities.nodemodel.v2", "snCombineColor")
-snCombineHSV = dynamic_import("mpfb.entities.nodemodel.v2", "snCombineHSV")
-snCombineRGB = dynamic_import("mpfb.entities.nodemodel.v2", "snCombineRGB")
 snCombineXYZ = dynamic_import("mpfb.entities.nodemodel.v2", "snCombineXYZ")
 snDisplacement = dynamic_import("mpfb.entities.nodemodel.v2", "snDisplacement")
 snEeveeSpecular = dynamic_import("mpfb.entities.nodemodel.v2", "snEeveeSpecular")
@@ -66,8 +64,6 @@ snRGBCurve = dynamic_import("mpfb.entities.nodemodel.v2", "snRGBCurve")
 snRGBToBW = dynamic_import("mpfb.entities.nodemodel.v2", "snRGBToBW")
 snScript = dynamic_import("mpfb.entities.nodemodel.v2", "snScript")
 snSeparateColor = dynamic_import("mpfb.entities.nodemodel.v2", "snSeparateColor")
-snSeparateHSV = dynamic_import("mpfb.entities.nodemodel.v2", "snSeparateHSV")
-snSeparateRGB = dynamic_import("mpfb.entities.nodemodel.v2", "snSeparateRGB")
 snSeparateXYZ = dynamic_import("mpfb.entities.nodemodel.v2", "snSeparateXYZ")
 snShaderToRGB = dynamic_import("mpfb.entities.nodemodel.v2", "snShaderToRGB")
 snSqueeze = dynamic_import("mpfb.entities.nodemodel.v2", "snSqueeze")
@@ -84,7 +80,6 @@ snTexMagic = dynamic_import("mpfb.entities.nodemodel.v2", "snTexMagic")
 if not SystemService.is_blender_version_at_least(version=[4, 1, 0]):
     snTexMusgrave = dynamic_import("mpfb.entities.nodemodel.v2", "snTexMusgrave")
 snTexNoise = dynamic_import("mpfb.entities.nodemodel.v2", "snTexNoise")
-snTexPointDensity = dynamic_import("mpfb.entities.nodemodel.v2", "snTexPointDensity")
 snTexSky = dynamic_import("mpfb.entities.nodemodel.v2", "snTexSky")
 snTexVoronoi = dynamic_import("mpfb.entities.nodemodel.v2", "snTexVoronoi")
 snTexWave = dynamic_import("mpfb.entities.nodemodel.v2", "snTexWave")
@@ -130,8 +125,6 @@ def test_primitives_are_available():
     assert snCameraData
     assert snClamp
     assert snCombineColor
-    assert snCombineHSV
-    assert snCombineRGB
     assert snCombineXYZ
     assert snDisplacement
     assert snEeveeSpecular
@@ -169,8 +162,6 @@ def test_primitives_are_available():
     assert snRGBToBW
     assert snScript
     assert snSeparateColor
-    assert snSeparateHSV
-    assert snSeparateRGB
     assert snSeparateXYZ
     assert snShaderToRGB
     assert snSqueeze
@@ -187,7 +178,6 @@ def test_primitives_are_available():
     if not SystemService.is_blender_version_at_least(version=[4, 1, 0]):
         assert snTexMusgrave
     assert snTexNoise
-    assert snTexPointDensity
     assert snTexSky
     assert snTexVoronoi
     assert snTexWave
@@ -426,26 +416,6 @@ def test_can_create_sncombinecolor():
     node = snCombineColor.create_instance(node_tree)
     assert node
     assert node.__class__.__name__ == "ShaderNodeCombineColor"
-    node_tree.nodes.remove(node)
-    NodeService.destroy_node_tree(node_tree)
-
-
-def test_can_create_sncombinehsv():
-    node_tree_name = ObjectService.random_name()
-    node_tree = NodeService.create_node_tree(node_tree_name)
-    node = snCombineHSV.create_instance(node_tree)
-    assert node
-    assert node.__class__.__name__ == "ShaderNodeCombineHSV"
-    node_tree.nodes.remove(node)
-    NodeService.destroy_node_tree(node_tree)
-
-
-def test_can_create_sncombinergb():
-    node_tree_name = ObjectService.random_name()
-    node_tree = NodeService.create_node_tree(node_tree_name)
-    node = snCombineRGB.create_instance(node_tree)
-    assert node
-    assert node.__class__.__name__ == "ShaderNodeCombineRGB"
     node_tree.nodes.remove(node)
     NodeService.destroy_node_tree(node_tree)
 
@@ -820,26 +790,6 @@ def test_can_create_snseparatecolor():
     NodeService.destroy_node_tree(node_tree)
 
 
-def test_can_create_snseparatehsv():
-    node_tree_name = ObjectService.random_name()
-    node_tree = NodeService.create_node_tree(node_tree_name)
-    node = snSeparateHSV.create_instance(node_tree)
-    assert node
-    assert node.__class__.__name__ == "ShaderNodeSeparateHSV"
-    node_tree.nodes.remove(node)
-    NodeService.destroy_node_tree(node_tree)
-
-
-def test_can_create_snseparatergb():
-    node_tree_name = ObjectService.random_name()
-    node_tree = NodeService.create_node_tree(node_tree_name)
-    node = snSeparateRGB.create_instance(node_tree)
-    assert node
-    assert node.__class__.__name__ == "ShaderNodeSeparateRGB"
-    node_tree.nodes.remove(node)
-    NodeService.destroy_node_tree(node_tree)
-
-
 def test_can_create_snseparatexyz():
     node_tree_name = ObjectService.random_name()
     node_tree = NodeService.create_node_tree(node_tree_name)
@@ -988,16 +938,6 @@ def test_can_create_sntexnoise():
     node = snTexNoise.create_instance(node_tree)
     assert node
     assert node.__class__.__name__ == "ShaderNodeTexNoise"
-    node_tree.nodes.remove(node)
-    NodeService.destroy_node_tree(node_tree)
-
-
-def test_can_create_sntexpointdensity():
-    node_tree_name = ObjectService.random_name()
-    node_tree = NodeService.create_node_tree(node_tree_name)
-    node = snTexPointDensity.create_instance(node_tree)
-    assert node
-    assert node.__class__.__name__ == "ShaderNodeTexPointDensity"
     node_tree.nodes.remove(node)
     NodeService.destroy_node_tree(node_tree)
 


### PR DESCRIPTION
Fix deprecations and limitations that prevented mpfb to run on blender 4.2.1 and alpha versions of blender 5. Solves issues #279 and #258.