### PR TITLE
Keep selection context after unloading assets.

### DIFF
--- a/src/mpfb/services/objectservice.py
+++ b/src/mpfb/services/objectservice.py
@@ -91,6 +91,11 @@ class ObjectService:
         context.view_layer.objects.active = object_to_make_active
 
     @staticmethod
+    def select_object(obj):
+        """Selects an object an makes it active."""
+        bpy.context.view_layer.objects.active = obj
+
+    @staticmethod
     def deselect_and_deactivate_all():
         """Make sure no object is selected nor active."""
         if bpy.context.object:

--- a/src/mpfb/ui/assetlibrary/operators/unloadlibraryclothes.py
+++ b/src/mpfb/ui/assetlibrary/operators/unloadlibraryclothes.py
@@ -54,8 +54,12 @@ class MPFB_OT_Unload_Library_Clothes_Operator(bpy.types.Operator):
         if not asset:
             self.report({'ERROR'}, "Could not find asset?")
             return {'FINISHED'}
+        
+        parent = basemesh.parent
 
         HumanService.unload_mhclo_asset(basemesh, asset)
+
+        ObjectService.select_object(parent)
 
         #_LOG.debug("Will call add_mhclo_asset: (asset_type, material_type)", (self.object_type, self.material_type))
         #HumanService.add_mhclo_asset(self.filepath, basemesh, asset_type=self.object_type, subdiv_levels=subdiv_levels, material_type=self.material_type)


### PR DESCRIPTION
# Description

## Problem
When a user plays around with clothes or other assets, they probably want to click through and try out different assets one after another. Previously, whenever the user unloaded an asset and clicked Load on the next asset, this caused an error to appear because nothing in the scene was selected anymore.

## Solution
This commit simple selects the direct parent of whatever was unloaded, right after the asset is unloaded, giving the next Load Asset Operation the context it needs to derive the base from.

