### PR TITLE
Add new roll strategy ALIGN_Z_REFERENCE_Z, for issue #310

### DIFF
--- a/src/mpfb/ui/boneops/boneproperties/roll_reference_z.json
+++ b/src/mpfb/ui/boneops/boneproperties/roll_reference_z.json
@@ -1,0 +1,7 @@
+{
+    "type": "vector_location",
+    "name": "roll_reference_z",
+    "description": "Reference vector for bone Z-axis",
+    "label": "Reference Z",
+    "default": [0.0, 0.0, 0.0]
+}

--- a/src/mpfb/ui/boneops/operators/set_roll_strategy.py
+++ b/src/mpfb/ui/boneops/operators/set_roll_strategy.py
@@ -33,6 +33,10 @@ class MPFB_OT_Set_Roll_Strategy_Operator(AbstractBoneOperator):
             "Align Z to World Z",
             "align bone Z to world Z"
         ),
+        "ALIGN_Z_REFERENCE_Z": (
+            "Use Current Z-axis as Reference",
+            "use the current Z-axis of the bone as reference"
+        ),
     }
 
     @classmethod
@@ -53,7 +57,12 @@ class MPFB_OT_Set_Roll_Strategy_Operator(AbstractBoneOperator):
 
         BoneOpsEditBoneProperties.set_value("roll_strategy", self.strategy, entity_reference=bone)
 
-        Rig.apply_bone_roll_strategy(bone, self.strategy)
+        if self.strategy == "ALIGN_Z_REFERENCE_Z":
+            reference_z = list(bone.z_axis)
+            BoneOpsEditBoneProperties.set_value("roll_reference_z", reference_z, entity_reference=bone)
+            Rig.apply_bone_roll_strategy(bone, self.strategy, reference_z)
+        else:
+            Rig.apply_bone_roll_strategy(bone, self.strategy)
 
         return {'FINISHED'}
 


### PR DESCRIPTION
This PR adds support for a new bone roll strategy, "ALIGN_Z_REFERENCE_Z". For a detailed discussion of the topic, see issue #310.

In short, this feature ensures that bone axes can be automatically aligned with a specified reference model. In certain use cases and runtime systems, this is necessary to enable reuse of existing poses and animations. By default, Blender determines bone axes heuristically, which is not acceptable in these scenarios, and the previously supported roll strategies are insufficient.

### Rig definition

When a bone's "roll_strategy" property in the rig file (.mpfbskel) is set to "ALIGN_Z_REFERENCE_Z", the reference vector can be specified using the new "roll_reference_z" property, defined as an [x, y, z] vector in armature space.

An example section from mpfbskel rig file:

```json
"roll": 3.12887,
"roll_strategy": "ALIGN_Z_REFERENCE_Z",
"roll_reference_z": [
    -0.15114,
    -0.08285,
    -0.98503
],
````

Note: In this example, the original "roll" value effectively serves as a fallback. It will be used if the new strategy is not implemented, for example when using an older MPFB version.

### UI:

This PR introduces minimal UI changes. Specifically, it adds the new roll strategy to the "MPFB Bone Strategies" panel:

![referencez](https://github.com/user-attachments/assets/c32a4767-db3e-4879-aeba-68a526dcf524)

If the strategy is initially set to "Use Current Z-axis as Reference", the reference Z value was/will be taken from the vector specified in the rig definition file. If the user manually changes the strategy to "Use Current Z-axis as Reference", the reference vector will be set to the bone's current Z-axis.

### Important

- This PR corrects the previous logic used when creating/refitting bones so that roll strategies are always applied **after all bones have been positioned**. This is important because, in Blender, aligning the roll of a child bone before the parent’s head and tail positions are finalized is unsafe.
- This PR also fixes a bug where the "roll_strategy" property was not saved when using "Save rig". In addition, if the saved strategy is "ALIGN_Z_REFERENCE_Z", the corresponding "roll_reference_z" value is now saved as well.

### Additional Notes

- The bone's final Z-axis will typically not be identical to the reference Z-axis because the reference vector is always projected onto the plane orthogonal to the bone’s Y-axis. This is expected behavior and should be taken into account during testing.
- The reference armature must use consistent bone directions to ensure that the X-axis is oriented correctly. In practice, this means that each corresponding bone must have its head and tail defined in the same order.
- In the related issue, the pseudocode explicitly performed the vector projection. While that approach is correct, Blender’s built-in `bone.align_roll(ref_z)` method already handles the projection internally, making an explicit implementation unnecessary.
- If the provided reference vector has zero length or is parallel (or nearly parallel) to the bone's Y-axis, the roll is undefined. In such cases, Blender selects an arbitrary but stable orientation. This is an inherent limitation of 3D mathematics. In practice, this is generally not problematic because the reference skeleton shares the same or a similar (human) structure.
- In the existing codebase, there appears to be some ambiguity regarding which set of values (rig definition versus pose/edit bone properties) should be considered authoritative in certain situations. However, this is a broader architectural issue and is not addressed in this PR.