### PR TITLE
chore: add PEP 484 type annotations to modifierservice.py

### DIFF
--- a/src/mpfb/services/modifierservice.py
+++ b/src/mpfb/services/modifierservice.py
@@ -1,6 +1,7 @@
 """This module contains utility functions for working with modifiers."""
 
 import bpy
+from typing import Any
 from .logservice import LogService
 
 _LOG = LogService.get_logger("services.modifierservice")
@@ -14,7 +15,7 @@ class ModifierService:
         raise RuntimeError("You should not instance ModifierService. Use its static methods instead.")
 
     @staticmethod
-    def move_modifier_to_top(blender_object, modifier_name):
+    def move_modifier_to_top(blender_object: bpy.types.Object, modifier_name: str) -> None:
         """Move a modifier to the top of the stack"""
         if not modifier_name or modifier_name not in blender_object.modifiers:
             return
@@ -23,7 +24,7 @@ class ModifierService:
                 bpy.ops.object.modifier_move_up(modifier=modifier_name)
 
     @staticmethod
-    def create_modifier(blender_object, modifier_name, modifier_type, move_to_top=False):
+    def create_modifier(blender_object: bpy.types.Object, modifier_name: str, modifier_type: str, move_to_top: bool = False) -> Any:
         """Create a new modifier for blender_object, of the given type. Optionally place it in the top of the stack."""
         if not blender_object:
             raise ValueError('Tried to call create_modifier for None object')
@@ -31,13 +32,13 @@ class ModifierService:
             raise ValueError('Tried to call create_modifier with an empty modifier type')
         if not modifier_name:
             raise ValueError('Tried to call create_modifier with an empty modifier name')
-        modifier = blender_object.modifiers.new(modifier_name, modifier_type)
+        modifier = blender_object.modifiers.new(modifier_name, modifier_type)  # type: ignore[arg-type]
         if move_to_top:
             ModifierService.move_modifier_to_top(blender_object, modifier_name)
         return modifier
 
     @staticmethod
-    def create_armature_modifier(blender_object, armature_object, modifier_name, show_in_editmode=True, show_on_cage=True, move_to_top=True):
+    def create_armature_modifier(blender_object: bpy.types.Object, armature_object: bpy.types.Object, modifier_name: str, show_in_editmode: bool = True, show_on_cage: bool = True, move_to_top: bool = True) -> Any:
         """Create an armature modifier for an object. Optionally place it in the top of the stack."""
         modifier = ModifierService.create_modifier(blender_object, modifier_name, 'ARMATURE', move_to_top=move_to_top)
         modifier.object = armature_object
@@ -46,7 +47,7 @@ class ModifierService:
         return modifier
 
     @staticmethod
-    def create_mask_modifier(blender_object, modifier_name, vertex_group, show_in_editmode=True, show_on_cage=True, move_to_top=False):
+    def create_mask_modifier(blender_object: bpy.types.Object, modifier_name: str, vertex_group: str, show_in_editmode: bool = True, show_on_cage: bool = True, move_to_top: bool = False) -> Any:
         """Create a mask modifier for blender_object, for the given vertex group. Optionally place it in the top of the stack."""
         modifier = ModifierService.create_modifier(blender_object, modifier_name, 'MASK', move_to_top=move_to_top)
         modifier.vertex_group = vertex_group
@@ -55,7 +56,7 @@ class ModifierService:
         return modifier
 
     @staticmethod
-    def create_subsurf_modifier(blender_object, modifier_name, levels=0, render_levels=1, show_in_editmode=True, move_to_top=False):
+    def create_subsurf_modifier(blender_object: bpy.types.Object, modifier_name: str, levels: int = 0, render_levels: int = 1, show_in_editmode: bool = True, move_to_top: bool = False) -> Any:
         """Create a subdiv modifier for blender_object. Optionally place it in the top of the stack."""
         modifier = ModifierService.create_modifier(blender_object, modifier_name, 'SUBSURF', move_to_top=move_to_top)
         modifier.levels = levels
@@ -64,7 +65,7 @@ class ModifierService:
         return modifier
 
     @staticmethod
-    def find_modifiers_of_type(blender_object, modifier_type):
+    def find_modifiers_of_type(blender_object: bpy.types.Object, modifier_type: str) -> list[bpy.types.Modifier]:
         """Return a list with all modifiers with a given type for the given object."""
         modifiers = []
         if not blender_object or not modifier_type:
@@ -75,7 +76,7 @@ class ModifierService:
         return modifiers
 
     @staticmethod
-    def find_modifier(blender_object, modifier_type, modifier_name=None):
+    def find_modifier(blender_object: bpy.types.Object, modifier_type: str, modifier_name: str | None = None) -> bpy.types.Modifier | None:
         """Return a modifier of the given type, optionally also limited by name"""
         if not blender_object:
             return None


### PR DESCRIPTION
Continuing the type annotation pass from #377 (logservice.py) and #378 (systemservice.py).

## What this changes

Adds PEP 484 type annotations to all 7 static methods in ModifierService. No logic changes.

blender_object / armature_object → bpy.types.Object (requires fake-bpy-module per requirements-dev.txt)
modifier return values (create_modifier, create_armature_modifier, create_mask_modifier, create_subsurf_modifier) remain Any — specific subclass attributes (.object, .vertex_group, .levels) are not on bpy.types.Modifier base; typed returns are a follow-up
modifier_name, modifier_type, vertex_group → str
show_in_editmode, show_on_cage, move_to_top → bool
levels, render_levels → int
Added from typing import Any import
Added # type: ignore[arg-type] on the modifiers.new() call — fake-bpy-module types the second argument as ObjectModifierTypeItems (a Literal union), not plain str; a cast here felt like scope creep

Pyright result
Baseline (before): 1 error, 0 warnings (bpy import unresolvable outside Blender)
After amendment: 0 errors, 1 warning — bpy.types.Object annotations with fake-bpy-module installed resolve the import, eliminating the error