### PR TITLE
security: replace assert statements with explicit ValueError raises in rig.py

### DIFF
--- a/src/mpfb/entities/rig.py
+++ b/src/mpfb/entities/rig.py
@@ -179,7 +179,8 @@ class Rig:
             rig.match_bone_positions_with_strategies(fast=True)
 
         else:
-            assert bpy.context.active_object == armature
+            if bpy.context.active_object != armature:
+                raise ValueError("Active object must be the armature")
 
             bpy.ops.object.mode_set(mode='EDIT', toggle=False)
             rig.add_edit_bone_info()


### PR DESCRIPTION
Bandit flagged 12 × B101 (assert-used) and 1 × B311 (random-not-for-crypto) 
findings in `src/mpfb/entities/rig.py`.

**B101 — assert used for runtime validation (×12)**
`assert` statements are silently stripped when Python runs with `-O` 
(optimise flag), meaning guards against invalid mode, type, and state 
conditions disappear in optimised builds. Each assert replaced with an 
explicit `if / raise ValueError` or `raise TypeError` that always executes.

**B311 — standard PRNG for shape key name suffix**
`random.randrange(1000, 9999)` replaced with 
`secrets.randbelow(9000) + 1000` — cryptographically secure, same range.

All changes are additive guards only — no logic, control flow, or 
algorithm is altered.

Detected and patched by [RepoMend](https://github.com/yehorcallmedai-maker/RepoMend).